### PR TITLE
Proposal to fix: #JERSEY-2490

### DIFF
--- a/docs/src/main/docbook/declarative-linking.xml
+++ b/docs/src/main/docbook/declarative-linking.xml
@@ -262,6 +262,24 @@ List&lt;Link&gt; links</programlisting>
             Multiple link headers can be added by use of the <literal>@InjectLinks</literal> annotation
             which can contain multiple <literal>@InjectLink</literal> annotations.
         </para>
+      </section>
+
+    <section>
+        <title>Prevent Recursive Injection</title>
+        <para>
+          	By default, Jersey will try to recursively find all <literal>@InjectionLink</literal> annotations in
+          	the members of your object unless this member is annotated with <literal>@XmlTransient</literal>.
+
+          	But is some cases, you might want to control which member will be introspected regardless of the
+			<literal>@XmlTransient</literal> annotation.
+
+          	You can prevent Jersey to look into an object by adding <literal>@InjectLinkNoFollow</literal> to a field.
+
+			<programlisting language="java">
+				@InjectLinkNoFollow
+				Context context;
+			</programlisting>
+        </para>
     </section>
 
     <section>

--- a/docs/src/main/docbook/declarative-linking.xml
+++ b/docs/src/main/docbook/declarative-linking.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -267,11 +267,11 @@ List&lt;Link&gt; links</programlisting>
     <section>
         <title>Prevent Recursive Injection</title>
         <para>
-          	By default, Jersey will try to recursively find all <literal>@InjectionLink</literal> annotations in
+            By default, Jersey will try to recursively find all <literal>@InjectionLink</literal> annotations in
           	the members of your object unless this member is annotated with <literal>@XmlTransient</literal>.
 
-          	But is some cases, you might want to control which member will be introspected regardless of the
-			<literal>@XmlTransient</literal> annotation.
+          	But in some cases, you might want to control which member will be introspected regardless of the
+            <literal>@XmlTransient</literal> annotation.
 
           	You can prevent Jersey to look into an object by adding <literal>@InjectLinkNoFollow</literal> to a field.
 

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/FieldProcessor.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/FieldProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/FieldProcessor.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/FieldProcessor.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Set;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.UriInfo;
+import javax.xml.bind.annotation.XmlTransient;
 
 import org.glassfish.jersey.linking.mapping.ResourceMappingContext;
 import org.glassfish.jersey.server.ExtendedUriInfo;
@@ -149,9 +150,18 @@ class FieldProcessor<T> {
 
         // Recursively process all member fields
         for (FieldDescriptor member : instanceDescriptor.getNonLinkFields()) {
-            processMember(entity, resource, member.getFieldValue(instance), processed, uriInfo,rmc);
+
+            if (fieldSuitableForIntrospection(member)) {
+                processMember(entity, resource, member.getFieldValue(instance), processed, uriInfo,rmc);
+            }
         }
 
+    }
+
+    private boolean fieldSuitableForIntrospection(FieldDescriptor member) {
+        return member.field == null
+                || (!member.field.isAnnotationPresent(InjectLinkNoFollow.class)
+                    && !member.field.isAnnotationPresent(XmlTransient.class));
     }
 
     private void processMember(Object entity, Object resource, Object member, Set<Object> processed, UriInfo uriInfo,

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkNoFollow.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkNoFollow.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkNoFollow.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkNoFollow.java
@@ -1,0 +1,61 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.linking;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.glassfish.jersey.Beta;
+
+/**
+ * Specifies on a field that should be ignored by Link recursive introspection.
+ *
+ * In some scenarios like with framework contexts or for more control,
+ * it is not wanted to try to find nested links into entities or collections.
+ *
+ * @author Aurelien Thieriot
+ */
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Beta
+public @interface InjectLinkNoFollow {
+}

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -75,6 +75,8 @@ import static org.junit.Assert.assertTrue;
  * @author Gerard Davison (gerard.davison at oracle.com)
  */
 public class FieldProcessorTest {
+
+    private static final Logger LOG = Logger.getLogger(FieldProcessor.class.getName()); 
 
     ExtendedUriInfo mockUriInfo = new ExtendedUriInfo() {
 
@@ -249,7 +251,8 @@ public class FieldProcessorTest {
 
     @Test
     public void testProcessLinks() {
-        System.out.println("Links");
+        LOG.info("Links");
+
         FieldProcessor<TestClassD> instance = new FieldProcessor(TestClassD.class);
         TestClassD testClass = new TestClassD();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -276,7 +279,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testProcessLinksWithFields() {
-        System.out.println("Links from field values");
+        LOG.info("Links from field values");
         FieldProcessor<TestClassE> instance = new FieldProcessor(TestClassE.class);
         TestClassE testClass = new TestClassE("10");
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -302,7 +305,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testNesting() {
-        System.out.println("Nesting");
+        LOG.info("Nesting");
         FieldProcessor<TestClassF> instance = new FieldProcessor(TestClassF.class);
         TestClassE nested = new TestClassE("10");
         TestClassF testClass = new TestClassF("20", nested);
@@ -313,7 +316,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testArray() {
-        System.out.println("Array");
+        LOG.info("Array");
         FieldProcessor<TestClassE[]> instance = new FieldProcessor(TestClassE[].class);
         TestClassE item1 = new TestClassE("10");
         TestClassE item2 = new TestClassE("20");
@@ -325,7 +328,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testCollection() {
-        System.out.println("Collection");
+        LOG.info("Collection");
         FieldProcessor<List> instance = new FieldProcessor(List.class);
         TestClassE item1 = new TestClassE("10");
         TestClassE item2 = new TestClassE("20");
@@ -361,7 +364,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testLinkStyles() {
-        System.out.println("Link styles");
+        LOG.info("Link styles");
         FieldProcessor<TestClassG> instance = new FieldProcessor(TestClassG.class);
         TestClassG testClass = new TestClassG("10");
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -382,7 +385,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testComputedProperty() {
-        System.out.println("Computed property");
+        LOG.info("Computed property");
         FieldProcessor<TestClassH> instance = new FieldProcessor(TestClassH.class);
         TestClassH testClass = new TestClassH();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -400,7 +403,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testEL() {
-        System.out.println("EL link");
+        LOG.info("El link");
         FieldProcessor<TestClassI> instance = new FieldProcessor(TestClassI.class);
         TestClassI testClass = new TestClassI();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -418,7 +421,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testMixed() {
-        System.out.println("Mixed EL and template vars link");
+        LOG.info("Mixed EL and template vars link");
         FieldProcessor<TestClassJ> instance = new FieldProcessor(TestClassJ.class);
         TestClassJ testClass = new TestClassJ();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -446,7 +449,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testELScopes() {
-        System.out.println("EL scopes");
+        LOG.info("EL scopes");
         FieldProcessor<OuterBean> instance = new FieldProcessor(OuterBean.class);
         OuterBean testClass = new OuterBean();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -465,7 +468,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testELBinding() {
-        System.out.println("EL binding");
+        LOG.info("EL binding");
         FieldProcessor<BoundLinkBean> instance = new FieldProcessor(BoundLinkBean.class);
         BoundLinkBean testClass = new BoundLinkBean();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -485,7 +488,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testELBindingOnLink() {
-        System.out.println("EL binding");
+        LOG.info("EL binding");
         FieldProcessor<BoundLinkOnLinkBean> instance = new FieldProcessor(BoundLinkOnLinkBean.class);
         BoundLinkOnLinkBean testClass = new BoundLinkOnLinkBean();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -525,7 +528,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testELBindingOnLinks() {
-        System.out.println("EL binding");
+        LOG.info("EL binding");
         FieldProcessor<BoundLinkOnLinksBean> instance = new FieldProcessor(BoundLinkOnLinksBean.class);
         BoundLinkOnLinksBean testClass = new BoundLinkOnLinksBean();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -562,7 +565,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testCondition() {
-        System.out.println("Condition");
+        LOG.info("Condition");
         FieldProcessor<ConditionalLinkBean> instance = new FieldProcessor(ConditionalLinkBean.class);
         ConditionalLinkBean testClass = new ConditionalLinkBean();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -586,7 +589,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testSubresource() {
-        System.out.println("Subresource");
+        LOG.info("Subresource");
         FieldProcessor<SubResourceBean> instance = new FieldProcessor(SubResourceBean.class);
         SubResourceBean testClass = new SubResourceBean();
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -632,7 +635,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testQueryResource() {
-        System.out.println("QueryResource");
+        LOG.info("QueryResource");
         FieldProcessor<QueryResourceBean> instance = new FieldProcessor(QueryResourceBean.class);
         QueryResourceBean testClass = new QueryResourceBean("queryExample", null);
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -641,7 +644,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testDoubleQueryResource() {
-        System.out.println("QueryResource");
+        LOG.info("QueryResource");
         FieldProcessor<QueryResourceBean> instance = new FieldProcessor(QueryResourceBean.class);
         QueryResourceBean testClass = new QueryResourceBean("queryExample", "queryExample2");
         instance.processLinks(testClass, mockUriInfo, mockRmc);
@@ -721,7 +724,7 @@ public class FieldProcessorTest {
 
     @Test
     public void testNoRecursiveNesting() {
-        System.out.println("No Recursive Nesting");
+        LOG.info("No Recursive Nesting");
         FieldProcessor<TestClassM> instance = new FieldProcessor(TestClassM.class);
         TestClassE nested = new TestClassE("10");
         TestClassE transientNested = new TestClassE("30");

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -57,6 +57,7 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.UriBuilder;
+import javax.xml.bind.annotation.XmlTransient;
 
 import org.glassfish.jersey.linking.mapping.ResourceMappingContext;
 import org.glassfish.jersey.server.ExtendedUriInfo;
@@ -693,5 +694,41 @@ public class FieldProcessorTest {
 
         Logger.getLogger(FieldDescriptor.class.getName()).setFilter(null);
 
+    }
+
+    public static class TestClassM {
+        @InjectLink(value = TEMPLATE_B, style = InjectLink.Style.RELATIVE_PATH)
+        private String thelink;
+
+        private String id;
+
+        @InjectLinkNoFollow
+        private TestClassE nested;
+
+        @XmlTransient
+        private TestClassE transientNested;
+
+        public TestClassM(String id, TestClassE e, TestClassE transientNested) {
+            this.id = id;
+            this.nested = e;
+            this.transientNested = transientNested;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+    @Test
+    public void testNoRecursiveNesting() {
+        System.out.println("No Recursive Nesting");
+        FieldProcessor<TestClassM> instance = new FieldProcessor(TestClassM.class);
+        TestClassE nested = new TestClassE("10");
+        TestClassE transientNested = new TestClassE("30");
+        TestClassM testClass = new TestClassM("20", nested, transientNested);
+        instance.processLinks(testClass, mockUriInfo, mockRmc);
+        assertEquals("widgets/20", testClass.thelink);
+        assertEquals(null, testClass.nested.link);
+        assertEquals(null, testClass.transientNested.link);
     }
 }


### PR DESCRIPTION
Hi,

   I encountered a similar situation as explained here: https://java.net/jira/browse/JERSEY-2490?jql=project%20%3D%20JERSEY%20AND%20text%20~%20%22declarative%20link%22

   My case was an entity, managed by Hibernate, with a lazy loaded collection inside. 
   Even though I am not interested in loading this collection (Doing so by adding @XmlTransient on it), the DeclarativeLinked feature still try to recursively search for @Link fields in the said collection.

   Therefore, like explained in the ticket, I think it makes sense to have a way to bypass the recursive search of Jersey on demand.
   To do so, I propose a new annotation to mark a field we would like to ignore.

   The change is pretty simple actually.
   The name would probably need to be adapt a little bit more to the Jersey notation though.

Please tell me if I need to change some things (names...), write some documentation or anything else.
I am very keen to contribute the right way.