### PR TITLE
Produce first declared content-type on Accept:*/*

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/MethodSelectingRouter.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/MethodSelectingRouter.java
@@ -602,16 +602,15 @@ final class MethodSelectingRouter implements Router {
         CombinedClientServerMediaType selected = null;
 
         for (final MediaType acceptableMediaType : acceptableMediaTypes) {
-            // Use writers suitable for entity class to determine the media type.
-            for (final MessageBodyWriter<?> writer : workers.getMessageBodyWritersForType(responseEntityClass)) {
-                for (final MediaType writerProduces : MediaTypes.createFrom(writer.getClass().getAnnotation(Produces.class))) {
+            // Media types producible by method.
+            final List<MediaType> methodProducesTypes = !resourceMethod.getProducedTypes().isEmpty() ?
+                    resourceMethod.getProducedTypes() : Lists.newArrayList(MediaType.WILDCARD_TYPE);
 
-                    if (writerProduces.isCompatible(acceptableMediaType)) {
-                        // Media types producible by method.
-                        final List<MediaType> methodProducesTypes = !resourceMethod.getProducedTypes().isEmpty() ?
-                                resourceMethod.getProducedTypes() : Lists.newArrayList(MediaType.WILDCARD_TYPE);
-
-                        for (final MediaType methodProducesType : methodProducesTypes) {
+            for (final MediaType methodProducesType : methodProducesTypes) {
+                // Use writers suitable for entity class to determine the media type.
+                for (final MessageBodyWriter<?> writer : workers.getMessageBodyWritersForType(responseEntityClass)) {
+                    for (final MediaType writerProduces : MediaTypes.createFrom(writer.getClass().getAnnotation(Produces.class))) {
+                        if (writerProduces.isCompatible(acceptableMediaType)) {
                             if (methodProducesType.isCompatible(writerProduces)) {
 
                                 final CombinedClientServerMediaType.EffectiveMediaType effectiveProduces = new
@@ -627,7 +626,6 @@ final class MethodSelectingRouter implements Router {
                                             || CombinedClientServerMediaType.COMPARATOR.compare(candidate, selected) > 0) {
                                         if (writer.isWriteable(responseEntityClass, entityType,
                                                 handlingMethod.getDeclaredAnnotations(), candidate.getCombinedMediaType())) {
-
                                             selected = candidate;
                                         }
                                     }

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/Resource.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/Resource.java
@@ -203,7 +203,7 @@ public final class Resource implements Routed, ResourceModelComponent {
         private List<String> names;
         private String path;
 
-        private final Set<ResourceMethod.Builder> methodBuilders;
+        private final List<ResourceMethod.Builder> methodBuilders;
         private final Set<Resource.Builder> childResourceBuilders;
         private final List<Resource.Data> childResources;
 
@@ -219,7 +219,7 @@ public final class Resource implements Routed, ResourceModelComponent {
 
 
         private Builder(final Resource.Builder parentResource) {
-            this.methodBuilders = Sets.newIdentityHashSet();
+            this.methodBuilders = Lists.newLinkedList();
             this.childResourceBuilders = Sets.newIdentityHashSet();
             this.childResources = Lists.newLinkedList();
             this.resourceMethods = Lists.newLinkedList();

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/ContentNegotiationTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/ContentNegotiationTest.java
@@ -67,39 +67,30 @@ public class ContentNegotiationTest extends JerseyTest {
 
     @Path("persons")
     public static class MyResource {
+        private static final Person[] LIST = new Person[] {
+                new Person("Penny", 1),
+                new Person("Howard", 2),
+                new Person("Sheldon", 3)
+        };
+
         @GET
         @Produces({"application/xml;qs=0.75", "application/json;qs=1.0"})
         public Person[] getList() {
-            Person[] list = new Person[3];
-            list[0] = new Person("Penny", 1);
-            list[1] = new Person("Howard", 2);
-            list[2] = new Person("Sheldon", 3);
-
-            return list;
+            return LIST;
         }
 
         @GET
         @Produces({"application/json;qs=1", "application/xml;qs=0.75"})
         @Path("reordered")
         public Person[] getListReordered() {
-            Person[] list = new Person[3];
-            list[0] = new Person("Penny", 1);
-            list[1] = new Person("Howard", 2);
-            list[2] = new Person("Sheldon", 3);
-
-            return list;
+            return LIST;
         }
 
         @GET
         @Produces({"application/json;qs=0.75", "application/xml;qs=1"})
         @Path("inverted")
         public Person[] getListInverted() {
-            Person[] list = new Person[3];
-            list[0] = new Person("Penny", 1);
-            list[1] = new Person("Howard", 2);
-            list[2] = new Person("Sheldon", 3);
-
-            return list;
+            return LIST;
         }
 
 
@@ -107,12 +98,28 @@ public class ContentNegotiationTest extends JerseyTest {
         @Produces({"application/xml;qs=0.75", "application/json;qs=0.9", "unknown/hello;qs=1.0"})
         @Path("unkownMT")
         public Person[] getListWithUnkownType() {
-            Person[] list = new Person[3];
-            list[0] = new Person("Penny", 1);
-            list[1] = new Person("Howard", 2);
-            list[2] = new Person("Sheldon", 3);
+            return LIST;
+        }
 
-            return list;
+        @GET
+        @Produces({"application/json", "application/xml", "text/plain"})
+        @Path("shouldPickFirst")
+        public Person[] getJsonArrayUnlessOtherwiseSpecified() {
+            return LIST;
+        }
+
+        @GET
+        @Produces("application/json")
+        @Path("twoMethodsOneEndpoint")
+        public Person[] getJsonArray() {
+            return LIST;
+        }
+
+        @GET
+        @Produces("application/xml")
+        @Path("twoMethodsOneEndpoint")
+        public Person[] getXmlArray() {
+            return LIST;
         }
     }
 
@@ -169,6 +176,20 @@ public class ContentNegotiationTest extends JerseyTest {
     public void testWithoutDefinedRequestedMediaType() {
         WebTarget target = target().path("/persons");
         Response response = target.request().get();
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+    }
+
+    @Test
+    public void testWithoutDefinedRequestedMediaTypeAndTwoMethods() {
+        Response response = target().path("/persons/twoMethodsOneEndpoint").request().get();
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+    }
+
+    @Test
+    public void testWithoutDefinedRequestedMediaTypeOrQualityModifiers() {
+        Response response = target().path("/persons/shouldPickFirst").request().get();
         Assert.assertEquals(200, response.getStatus());
         Assert.assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
     }


### PR DESCRIPTION
This is a fix to reported issue JERSEY-2635, stemming from
the incorrect ordering of for loops in MethodSelectingRouter.