### PR TITLE
Cache SSLSocketFactory so that connections can be reused. (JERSEY-2675)

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/HttpUrlConnector.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/HttpUrlConnector.java
@@ -278,7 +278,7 @@ class HttpUrlConnector implements Connector {
             if (verifier != null) {
                 suc.setHostnameVerifier(verifier);
             }
-            suc.setSSLSocketFactory(client.getSslContext().getSocketFactory());
+            suc.setSSLSocketFactory(client.getSslSocketFactory());
         }
 
         final Object entity = request.getEntity();
@@ -336,7 +336,7 @@ class HttpUrlConnector implements Connector {
         return responseContext;
     }
 
-    private void setOutboundHeaders(MultivaluedMap<String, String> headers, HttpURLConnection uc) {
+  private void setOutboundHeaders(MultivaluedMap<String, String> headers, HttpURLConnection uc) {
         boolean restrictedSent = false;
         for (Map.Entry<String, List<String>> header : headers.entrySet()) {
             String headerName = header.getKey();

--- a/core-client/src/main/java/org/glassfish/jersey/client/HttpUrlConnector.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/HttpUrlConnector.java
@@ -336,7 +336,7 @@ class HttpUrlConnector implements Connector {
         return responseContext;
     }
 
-  private void setOutboundHeaders(MultivaluedMap<String, String> headers, HttpURLConnection uc) {
+    private void setOutboundHeaders(MultivaluedMap<String, String> headers, HttpURLConnection uc) {
         boolean restrictedSent = false;
         for (Map.Entry<String, List<String>> header : headers.entrySet()) {
             String headerName = header.getKey();

--- a/core-client/src/main/java/org/glassfish/jersey/client/JerseyClient.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/JerseyClient.java
@@ -170,6 +170,8 @@ public class JerseyClient implements javax.ws.rs.client.Client, Initializable<Je
     /**
      * Lazily gets the SSL socket factory connected to the SSLContext.
      * The instance is cached for a subsequent retrieval.
+     * Use this to avoid getting new instances of the factory from SSLContextImpl every time the
+     * getter is called.
      *
      * @return {@code SSLSocketFactory} from the {@code SSLContext}. Created on first retrieval.
      */

--- a/core-client/src/main/java/org/glassfish/jersey/client/JerseyClient.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/JerseyClient.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.net.ssl.SSLSocketFactory;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.UriBuilder;
@@ -56,6 +57,7 @@ import javax.net.ssl.SSLContext;
 import org.glassfish.jersey.SslConfigurator;
 import org.glassfish.jersey.client.internal.LocalizationMessages;
 import org.glassfish.jersey.internal.util.collection.UnsafeValue;
+import org.glassfish.jersey.internal.util.collection.Value;
 import org.glassfish.jersey.internal.util.collection.Values;
 
 import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
@@ -75,8 +77,9 @@ public class JerseyClient implements javax.ws.rs.client.Client, Initializable<Je
     private final HostnameVerifier hostnameVerifier;
     private final UnsafeValue<SSLContext, IllegalStateException> sslContext;
     private final LinkedBlockingDeque<ShutdownHook> shutdownHooks = new LinkedBlockingDeque<ShutdownHook>();
+    private final Value<SSLSocketFactory> sslSocketFactory;
 
-    /**
+  /**
      * Client instance shutdown hook.
      */
     static interface ShutdownHook {
@@ -118,6 +121,12 @@ public class JerseyClient implements javax.ws.rs.client.Client, Initializable<Je
                            final HostnameVerifier verifier) {
         this.config = config == null ? new ClientConfig(this) : new ClientConfig(this, config);
         this.sslContext = Values.lazy(sslContextProvider != null ? sslContextProvider : createSslContextProvider());
+        this.sslSocketFactory = Values.lazy(new Value<SSLSocketFactory>() {
+          @Override
+          public SSLSocketFactory get() {
+            return sslContext.get().getSocketFactory();
+          }
+        });
         this.hostnameVerifier = verifier;
     }
 
@@ -156,6 +165,16 @@ public class JerseyClient implements javax.ws.rs.client.Client, Initializable<Je
     void registerShutdownHook(final ShutdownHook shutdownHook) {
         checkNotClosed();
         shutdownHooks.push(shutdownHook);
+    }
+
+    /**
+     * Lazily gets the SSL socket factory connected to the SSLContext.
+     * The instance is cached for a subsequent retrieval.
+     *
+     * @return {@code SSLSocketFactory} from the {@code SSLContext}. Created on first retrieval.
+     */
+    protected SSLSocketFactory getSslSocketFactory() {
+      return sslSocketFactory.get();
     }
 
     /**

--- a/core-client/src/main/java/org/glassfish/jersey/client/JerseyClient.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/JerseyClient.java
@@ -79,7 +79,7 @@ public class JerseyClient implements javax.ws.rs.client.Client, Initializable<Je
     private final LinkedBlockingDeque<ShutdownHook> shutdownHooks = new LinkedBlockingDeque<ShutdownHook>();
     private final Value<SSLSocketFactory> sslSocketFactory;
 
-  /**
+    /**
      * Client instance shutdown hook.
      */
     static interface ShutdownHook {

--- a/core-client/src/test/java/org/glassfish/jersey/client/ClientConfigTest.java
+++ b/core-client/src/test/java/org/glassfish/jersey/client/ClientConfigTest.java
@@ -42,6 +42,7 @@ package org.glassfish.jersey.client;
 import java.util.Arrays;
 import java.util.Map;
 
+import javax.net.ssl.SSLSocketFactory;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -62,6 +63,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -250,5 +252,13 @@ public class ClientConfigTest {
         assertFalse(instance.getProperties().isEmpty());
         assertEquals(1, instance.getProperties().size());
         assertEquals("value", instance.getProperty("name"));
+    }
+
+    @Test
+    public void testSSLSocketFactoryReuse() throws Exception {
+      JerseyClient jerseyClient = new JerseyClient(null, SSLContext.getDefault(), null);
+      SSLSocketFactory sslSocketFactory = jerseyClient.getSslSocketFactory();
+      assertNotNull(sslSocketFactory);
+      assertSame(sslSocketFactory, jerseyClient.getSslSocketFactory());
     }
 }


### PR DESCRIPTION
When using your own SSLContext in JerseyClient we found that the connections never were reused even though Keep-Alive was set. After some digging I found that the cache uses the SSLSocketFactory to lookup connections in the cache and that Jersey HttpUrlConnector always fetched the factory from the provided SLLContext and put it in HttpsURLConnection. 
The problem here was that the getSocketFactory method on SSLContextImpl always created new SSLSocketFactories and therefore connection lookup always failed. Hence new connections were created on each request.
This is a problem when calling resources far away (like across the Atlantic as in our case) where normal requests take approximately 200ms but with connection establishment and SSL handshake each request takes about 700ms.
This change will not enable this by any configuration, it will be the de facto setting. So if that would be a breaker I could make this configurable via a provider specific property and leave the old behaviour as default.