### PR TITLE
[JERSEY-2680] Catch bubbling IllegalArgumentException

### DIFF
--- a/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/ServletContainer.java
+++ b/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/ServletContainer.java
@@ -330,7 +330,7 @@ public class ServletContainer extends HttpServlet implements Filter, Container {
             requestUri = absoluteUriBuilder.replacePath(requestURI).
                     replaceQuery(queryParameters).
                     build();
-        } catch (UriBuilderException ex) {
+        } catch (UriBuilderException | IllegalArgumentException ex) {
             final Response.Status badRequest = Response.Status.BAD_REQUEST;
             if (webComponent.configSetStatusOverSendError) {
                 response.reset();


### PR DESCRIPTION
Also catch IllegalArgumentException that can be thrown by UriTemplate which is called by JerseyUriBuilder. If there is an IllegalArgumentException during URL parsing it is very probable that the URL is malformed so I think catching is reasonable. This is also analogous to line 290 that has the same catch.

Jira-Ticket: https://java.net/jira/browse/JERSEY-2680