### PR TITLE
ApacheConnector: Set timeouts on per-request basis

### DIFF
--- a/connectors/apache-connector/src/test/java/org/glassfish/jersey/apache/connector/TimeoutTest.java
+++ b/connectors/apache-connector/src/test/java/org/glassfish/jersey/apache/connector/TimeoutTest.java
@@ -115,4 +115,12 @@ public class TimeoutTest extends JerseyTest {
                     e.getCause(), instanceOf(SocketTimeoutException.class));
         }
     }
+
+    @Test
+    public void testPerRequestTimeout() {
+        Response r = target("test/timeout").request()
+                .property(ClientProperties.READ_TIMEOUT, 3000).get();
+        assertEquals(200, r.getStatus());
+        assertEquals("GET", r.readEntity(String.class));
+    }
 }


### PR DESCRIPTION
This better matches the behavior of the HttpUrlConnector.

Fixes: https://java.net/jira/browse/JERSEY-2698.