### PR TITLE
JERSEY-2718 cleanup code

### DIFF
--- a/core-client/src/test/java/org/glassfish/jersey/client/filter/EncodingFilterTest.java
+++ b/core-client/src/test/java/org/glassfish/jersey/client/filter/EncodingFilterTest.java
@@ -100,7 +100,7 @@ public class EncodingFilterTest {
                 DeflateEncoder.class
         ).property(ClientProperties.USE_ENCODING, "gzip").connectorProvider(new TestConnector()));
         Invocation.Builder invBuilder = client.target(UriBuilder.fromUri("/").build()).request();
-        Response r = invBuilder.post(Entity.entity(new String("Hello world"), MediaType.TEXT_PLAIN_TYPE));
+        Response r = invBuilder.post(Entity.entity("Hello world", MediaType.TEXT_PLAIN_TYPE));
         assertEquals("deflate,gzip,x-gzip", r.getHeaderString(ACCEPT_ENCODING));
         assertEquals("gzip", r.getHeaderString(CONTENT_ENCODING));
     }
@@ -111,7 +111,7 @@ public class EncodingFilterTest {
                 .connectorProvider(new TestConnector())
                 .register(new EncodingFeature("gzip", GZipEncoder.class, DeflateEncoder.class)));
         Invocation.Builder invBuilder = client.target(UriBuilder.fromUri("/").build()).request();
-        Response r = invBuilder.post(Entity.entity(new String("Hello world"), MediaType.TEXT_PLAIN_TYPE));
+        Response r = invBuilder.post(Entity.entity("Hello world", MediaType.TEXT_PLAIN_TYPE));
         assertEquals("deflate,gzip,x-gzip", r.getHeaderString(ACCEPT_ENCODING));
         assertEquals("gzip", r.getHeaderString(CONTENT_ENCODING));
     }

--- a/core-common/src/main/java/org/glassfish/jersey/internal/l10n/Localizer.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/l10n/Localizer.java
@@ -114,7 +114,7 @@ public class Localizer {
                                 if (osgiRegistry != null) {
                                     bundle = osgiRegistry.getResourceBundle(bundlename);
                                 } else {
-                                    final String path = new StringBuilder(bundlename.replace('.', '/')).append(".properties").toString();
+                                    final String path = bundlename.replace('.', '/') + ".properties";
                                     final URL bundleUrl = ResourceFinder.findEntry(path);
                                     if (bundleUrl != null) {
                                         try {

--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/ExtendedLogger.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/ExtendedLogger.java
@@ -117,13 +117,7 @@ public final class ExtendedLogger {
             }
             messageArguments[messageArguments.length - 1] = Thread.currentThread().getName();
 
-            final StringBuilder messageBuilder = new StringBuilder(messageTemplate.length() + 25);
-            messageBuilder
-                    .append("[DEBUG] ")
-                    .append(messageTemplate)
-                    .append(" on thread {").append(messageArguments.length - 1).append('}');
-
-            logger.log(debugLevel, messageBuilder.toString(), messageArguments);
+            logger.log(debugLevel, "[DEBUG] " + messageTemplate + " on thread {" + (messageArguments.length - 1) + '}', messageArguments);
         }
     }
 

--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/JdkVersion.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/JdkVersion.java
@@ -148,14 +148,7 @@ public class JdkVersion implements Comparable<JdkVersion> {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("JdkVersion");
-        sb.append("{major=").append(major);
-        sb.append(", minor=").append(minor);
-        sb.append(", maintenance=").append(maintenance);
-        sb.append(", update=").append(update);
-        sb.append('}');
-        return sb.toString();
+        return "JdkVersion" + "{major=" + major + ", minor=" + minor + ", maintenance=" + maintenance + ", update=" + update + '}';
     }
 
     // ------------------------------------------------- Methods from Comparable

--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/ReflectionHelper.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/ReflectionHelper.java
@@ -139,10 +139,7 @@ public class ReflectionHelper {
         if (o == null) {
             return "null";
         }
-        StringBuilder sb = new StringBuilder();
-        sb.append(o.getClass().getName()).
-                append('@').append(Integer.toHexString(o.hashCode()));
-        return sb.toString();
+        return o.getClass().getName() + '@' + Integer.toHexString(o.hashCode());
     }
 
     /**
@@ -327,7 +324,7 @@ public class ReflectionHelper {
             public Field[] run() {
             	final List<Field> fields = new ArrayList<Field>();
             	recurse(clazz, fields);
-                return fields.toArray(new Field[0]);
+                return fields.toArray(new Field[fields.size()]);
             }
             
            private void recurse(final Class<?> clazz, final List<Field> fields) {

--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/collection/ConcurrentHashMapV8.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/collection/ConcurrentHashMapV8.java
@@ -3417,8 +3417,7 @@ class ConcurrentHashMapV8<K, V> extends AbstractMap<K, V>
                     try {
                         if (counterCells == as) {// Expand table unless stale
                             CounterCell[] rs = new CounterCell[n << 1];
-                            for (int i = 0; i < n; ++i)
-                                rs[i] = as[i];
+                            System.arraycopy(as, 0, rs, 0, n);
                             counterCells = rs;
                         }
                     } finally {

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/LocaleProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/LocaleProvider.java
@@ -71,8 +71,7 @@ public class LocaleProvider implements HeaderDelegateProvider<Locale> {
         if (header.getCountry().length() == 0) {
             return header.getLanguage();
         } else {
-            StringBuilder sb = new StringBuilder(header.getLanguage());
-            return sb.append('-').append(header.getCountry()).toString();
+            return header.getLanguage() + '-' + header.getCountry();
         }
     }
 

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/NounInflector.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/NounInflector.java
@@ -640,7 +640,10 @@ final class NounInflector {
             return word;
         }
         // otherwise turn the first character to lower case and attach the rest
-        return String.valueOf(Character.toLowerCase(first)) + word.substring(1);
+     	StringBuilder sb = new StringBuilder(word.length());
+	sb.append(Character.toLowerCase(first));
+	sb.append(word.substring(1));
+	return sb.toString();
     }
 
     /**

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/NounInflector.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/NounInflector.java
@@ -640,10 +640,7 @@ final class NounInflector {
             return word;
         }
         // otherwise turn the first character to lower case and attach the rest
-        StringBuilder sb = new StringBuilder(word.length());
-        sb.append(Character.toLowerCase(first));
-        sb.append(word.substring(1));
-        return sb.toString();
+        return String.valueOf(Character.toLowerCase(first)) + word.substring(1);
     }
 
     /**

--- a/core-server/src/main/java/org/glassfish/jersey/server/filter/UriConnegFilter.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/filter/UriConnegFilter.java
@@ -249,8 +249,8 @@ public class UriConnegFilter implements ContainerRequestFilter {
             parseMappings(property, (String) mappings, mappingsMap, parser);
         } else if (mappings instanceof String[]) {
             final String[] mappingsArray = (String[])mappings;
-            for (int i = 0; i < mappingsArray.length; i++) {
-                parseMappings(property, mappingsArray[i], mappingsMap, parser);
+            for (final String aMappingsArray : mappingsArray) {
+                parseMappings(property, aMappingsArray, mappingsMap, parser);
             }
         } else {
             throw new IllegalArgumentException(LocalizationMessages.INVALID_MAPPING_TYPE(property));

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/monitoring/jmx/MBeanExposer.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/monitoring/jmx/MBeanExposer.java
@@ -121,10 +121,8 @@ public class MBeanExposer extends AbstractContainerLifecycleListener implements 
         String str = name.replace("\\", "\\\\");
         str = str.replace("?", "\\?");
         str = str.replace("*", "\\*");
-        StringBuilder sb = new StringBuilder();
-        sb.append("\"").append(str).append("\"");
 
-        return sb.toString();
+        return "\"" + str + "\"";
     }
 
     /**

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/Resource.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/Resource.java
@@ -858,9 +858,7 @@ public final class Resource implements Routed, ResourceModelComponent {
                     return data.names.get(0);
                 } else {
                     // return merged name
-                    StringBuilder nameBuilder = new StringBuilder("Merge of ");
-                    nameBuilder.append(data.names.toString());
-                    return nameBuilder.toString();
+                    return "Merge of " + data.names.toString();
                 }
             }
         });

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceModelIssue.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceModelIssue.java
@@ -114,12 +114,7 @@ public final class ResourceModelIssue {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("[").append(severity).append("] ");
-        ;
-        sb.append(message);
-        sb.append("; source='").append(source).append('\'');
-        return sb.toString();
+        return "[" + severity + "] " + message + "; source='" + source + '\'';
     }
 
     @Override


### PR DESCRIPTION
* fix performance issue: StringBuilder is not necessary for compile time constants or final references
* fix performance issue: use a pre-defined array size when converting a list to an array
* fix performance issue: copy an array using JVM's pre-defined utility method