### PR TITLE
Fix InjectLinks code sample in HTTP Link headers section of docbook

### DIFF
--- a/docs/src/main/docbook/declarative-linking.xml
+++ b/docs/src/main/docbook/declarative-linking.xml
@@ -231,8 +231,7 @@ List&lt;Link&gt; links</programlisting>
             <literal>@InjectLink</literal>, you instead annotate the entity class itself with
             <literal>@InjectLinks</literal>. E.g.:
             <programlisting language="java">@InjectLinks(
-    value=@InjectLink("widgets/${resource.nextId}"),
-    rel="next"
+    @InjectLink(value="widgets/${resource.nextId}", rel="next")
 )</programlisting>
         </para>
 


### PR DESCRIPTION
There's a typo in HTTP Link headers section