### PR TITLE
JERSEY-2724 Added support for toString in proxy client

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -160,6 +160,10 @@ public final class WebResourceFactory implements InvocationHandler {
     @Override
     @SuppressWarnings("unchecked")
     public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+        if (args == null && method.getName().equals("toString")) {
+            return toString();
+        }
+
         // get the interface describing the resource
         final Class<?> proxyIfc = proxy.getClass().getInterfaces()[0];
 
@@ -364,6 +368,11 @@ public final class WebResourceFactory implements InvocationHandler {
             target = target.path(p.value());
         }
         return target;
+    }
+
+    @Override
+    public String toString() {
+        return target.toString();
     }
 
     private static String getHttpMethodName(final AnnotatedElement ae) {

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -331,4 +331,11 @@ public class WebResourceFactoryTest extends JerseyTest {
         assertEquals("Content-Type HTTP header does not match explicitly provided type", resourceWithXML.putIt(new MyBean()), MediaType.APPLICATION_XML);
     }
 
+    @Test
+    public void testToString() throws Exception {
+        String actual = resource.toString();
+        String expected = target().path("myresource").toString();
+
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
If I call `toString()` on a proxy client, it throws an `UnsupportedOperationException`:

````
@Path("/")
interface MyClient {
    @GET String get();
}

@Test
public void buildClient() {
    WebTarget target = ClientBuilder.newClient()
                            .target("http://localhost/");

    MyClient client = WebResourceFactory.newResource(MyClient.class, target);

    client.toString(); //<-- throws java.lang.UnsupportedOperationException: Not a resource method
}
```
It's not a good thing to throw exceptions in `toString`. This PR add support for handling `toString` calls in the invocation handler.

Guava has an [AbstractInvocationHandler](https://github.com/google/guava/blob/fa95e381e665d8ee9639543b99ed38020c8de5ef/guava/src/com/google/common/reflect/AbstractInvocationHandler.java) where this logic is implemented (`hashCode` and `equals` as well). But the guava artifact is not in the proxy-client's pom. A better solution would be to use the guava's `AbstractInvocationHandler`, but I don't have the knowledge to decide on wether it's a good idea to add that dependency to the pom.

JIRA issue:
https://java.net/jira/browse/JERSEY-2724


