### PR TITLE
Fix various issues with JarFileScanner

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/JarFileScanner.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/JarFileScanner.java
@@ -58,7 +58,7 @@ public final class JarFileScanner implements ResourceFinder {
 
     private static final Logger LOGGER = Logger.getLogger(JarFileScanner.class.getName());
     // platform independent file separator within the jar file
-    private static final char JAR_FILE_SEPARATOR = '\\';
+    private static final char JAR_FILE_SEPARATOR = '/';
 
     private final JarInputStream jarInputStream;
     private final String parent;
@@ -91,14 +91,17 @@ public final class JarFileScanner implements ResourceFinder {
                         break;
                     }
                     if (!next.isDirectory() && next.getName().startsWith(parent)) {
+                        final String suffix = next.getName().substring(parent.length());
                         if (recursive) {
                             // accept any entries with the prefix
-                            break;
-                        }
-                        // accept only entries directly in the folder.
-                        final String suffix = next.getName().substring(parent.length());
-                        if (suffix.lastIndexOf(JAR_FILE_SEPARATOR) <= 0) {
-                            break;
+                            if (parent.isEmpty() || suffix.indexOf(JAR_FILE_SEPARATOR) == 0) {
+                                break;
+                            }
+                        } else {
+                            // accept only entries directly in the folder.
+                            if (suffix.lastIndexOf(JAR_FILE_SEPARATOR) == (parent.isEmpty() ? -1 : 0)) {
+                                break;
+                            }
                         }
                     }
                 } while (true);


### PR DESCRIPTION
This PR aims to correct the fix for [JERSEY-2621](https://java.net/jira/browse/JERSEY-2621) (cc89c97f2f5732d80d56908c224887515e80c689). It also addresses some other edge cases. Details are in the commit message:

> Overview:
- Previously `JarFileScanner` assumed backslashes to be the platform independent file separator for zip files. This is incorrect (and in fact, the associated unit tests did assume forward slashes, using "`javax/ws/rs`" to denote the package "`javax.ws.rs`"). See [1] for details.
- As a result the non-recursive scanning mode was broken: failing to find the backslash delimiter, the scanner would return classes from subpackages even when it was instructed not to do so. This has been fixed.
- The scanner also did not verify that "matching" classes were in a proper subdirectory of the indicated package. As a result a class such as `javax.ws.rs.GET` was matched for the following "packages":
    - `javax/ws/r` (too short, misses an "`s`")
    - `javax/ws/rs/GE` (too long, includes class name prefix)    
  
>  This has been fixed as well.
> 
> The class' unit tests were extended to cover the problematic cases. Of the five new unit tests, three fail prior to the fix.
> 
> [1] https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT

NB: I already signed the OCA, in the context of #80.