### PR TITLE
Added functionality to optionally extract provided Content-Type in Header

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2012-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -73,6 +73,7 @@ import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -290,13 +291,17 @@ public final class WebResourceFactory implements InvocationHandler {
         // determine content type
         String contentType = null;
         if (entity != null) {
-            Consumes consumes = method.getAnnotation(Consumes.class);
-            if (consumes == null) {
-                consumes = proxyIfc.getAnnotation(Consumes.class);
-            }
-            if (consumes != null && consumes.value().length > 0) {
-                // TODO: should consider q/qs instead of picking the first one
-                contentType = consumes.value()[0];
+            List<Object> contentTypeEntries = headers.get(HttpHeaders.CONTENT_TYPE);
+            if ((contentTypeEntries != null) && (!contentTypeEntries.isEmpty())) {
+                contentType = contentTypeEntries.get(0).toString();
+            } else {
+                Consumes consumes = method.getAnnotation(Consumes.class);
+                if (consumes == null) {
+                    consumes = proxyIfc.getAnnotation(Consumes.class);
+                }
+                if (consumes != null && consumes.value().length > 0) {
+                    contentType = consumes.value()[0];
+                }
             }
         }
 

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2012-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
@@ -39,13 +39,17 @@
  */
 package org.glassfish.jersey.client.proxy;
 
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 
 public class MyResource implements MyResourceIfc {
+
+    @Context HttpHeaders headers;
 
     @Override
     public String getIt() {
@@ -176,5 +180,10 @@ public class MyResource implements MyResourceIfc {
     public boolean isAcceptHeaderValid(HttpHeaders headers) {
         List<MediaType> accepts = headers.getAcceptableMediaTypes();
         return accepts.contains(MediaType.TEXT_PLAIN_TYPE) && accepts.contains(MediaType.TEXT_XML_TYPE);
+    }
+
+    @Override
+    public String putIt(MyBean dummyBean) {
+        return headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
     }
 }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2012-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
@@ -50,6 +50,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.MatrixParam;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -188,4 +189,9 @@ public interface MyResourceIfc {
     @GET
     @Produces({MediaType.TEXT_PLAIN, MediaType.TEXT_XML})
     boolean isAcceptHeaderValid(@Context HttpHeaders headers);
+
+    @Path("putIt")
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    String putIt(MyBean dummyBean);
 }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2012-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -47,17 +47,25 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
-
 import org.junit.Ignore;
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class WebResourceFactoryTest extends JerseyTest {
     private MyResourceIfc resource;
+    private MyResourceIfc resourceWithXML;
 
     @Override
     protected ResourceConfig configure() {
@@ -74,6 +82,10 @@ public class WebResourceFactoryTest extends JerseyTest {
     public void setUp() throws Exception {
         super.setUp();
         resource = WebResourceFactory.newResource(MyResourceIfc.class, target());
+
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<String, Object>(1);
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML);
+        resourceWithXML = WebResourceFactory.newResource(MyResourceIfc.class, target(), false, headers, Collections.<Cookie>emptyList(), new Form());
     }
 
     @Test
@@ -312,6 +324,11 @@ public class WebResourceFactoryTest extends JerseyTest {
     @Test
     public void testAcceptHeader() {
         assertTrue("Accept HTTP header does not match @Produces annotation", resource.isAcceptHeaderValid(null));
+    }
+
+    @Test
+    public void testPutWithExplicitContentType() {
+        assertEquals("Content-Type HTTP header does not match explicitly provided type", resourceWithXML.putIt(new MyBean()), MediaType.APPLICATION_XML);
     }
 
 }


### PR DESCRIPTION
We need a mechanism to invoke a dynamic client proxy with a specific content-type which is not necessarily identical with the first value in the “@Consumes” annotation. In analogy, providing a custom “Accept”-Header is already working.

The provided piece of code solves the problem for us. It could be considerable to try to match the header-value against the list of consumed content-types of the actual service, but for several reasons we decided to use the provided header without validating it. We left it to the service to make the final decision to accept the content-type or not.
