### PR TITLE
Make hasEntity() work with a closed stream.

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/InboundMessageContext.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/InboundMessageContext.java
@@ -741,8 +741,6 @@ public abstract class InboundMessageContext {
      *         {@code false} otherwise.
      */
     public boolean hasEntity() {
-        entityContent.ensureNotClosed();
-
         try {
             return !entityContent.isEmpty();
         } catch (IllegalStateException ex) {

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/client/ResponseCloseTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/client/ResponseCloseTest.java
@@ -49,6 +49,8 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 /**
@@ -160,10 +162,10 @@ public class ResponseCloseTest extends JerseyTest {
         final Response response = target().path("simple").request().get(Response.class);
         response.close();
         try {
-            response.hasEntity();
-            fail("IllegalStateException expected when reading a buffered entity after response has been closed.");
+            boolean hasEntity = response.hasEntity();
+            assertFalse("Should return false when the connection is already closed", hasEntity);
         } catch (IllegalStateException ex) {
-            // expected
+            fail("IllegalStateException should have been caught inside hasEntity.");
         }
     }
 }


### PR DESCRIPTION
InboundMessageContext.hasEntity() currently throws an IllegalStateException outside the try catch due to the extra call to entityContent.ensureNotClosed() if the entity stream is already closed.

This check is not needed here due to EntityInputStream.isEmpty() calling ensureNotClosed() internally.