### PR TITLE
JerseyTest.tearDown to be more careful

### DIFF
--- a/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
+++ b/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
+++ b/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
@@ -631,7 +631,10 @@ public abstract class JerseyTest {
         }
 
         try {
-            setTestContainer(null).stop();
+            TestContainer oldContainer = setTestContainer(null);
+            if (oldContainer != null) {
+                oldContainer.stop();
+            }
         } finally {
             closeIfNotNull(setClient(null));
         }


### PR DESCRIPTION
To handle cases when tearDown throws an exception and makes exception from setup/test methods swallowed/overwritten.

Really helps with debugging setup problems. In my case corresponding setUp did not complete correctly and old test container was null.