### PR TITLE
easy configuration for freemarker

### DIFF
--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerConfigurationFactory.java
@@ -43,6 +43,6 @@ import freemarker.template.Configuration;
 
 public interface FreemarkerConfigurationFactory {
 
-    public Configuration getInstance();
+    public Configuration getConfiguration();
 
 }

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerConfigurationFactory.java
@@ -41,6 +41,20 @@ package org.glassfish.jersey.server.mvc.freemarker;
 
 import freemarker.template.Configuration;
 
+
+/**
+ * Provides lookup of {@link freemarker.template.Configuration Configuration}
+ * instance for Freemarker templating.
+ * </p>
+ * Instantiation of Configuration objects is relatively heavy-weight, and
+ * Freemarker best-practices dictate that they be reused if possible.
+ * Therefore, most implementations of this interface will only create a
+ * singleton Configuration instance, and return it for every call to
+ * {@link #getConfiguration()}. Although this will usually be the case, it is
+ * not a guarantee of this interface's contract.
+ *
+ * @author Jeff Wilde (jeff.wilde at complicatedrobot.com)
+ */
 public interface FreemarkerConfigurationFactory {
 
     public Configuration getConfiguration();

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerConfigurationFactory.java
@@ -1,0 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.jersey.server.mvc.freemarker;
+
+import freemarker.template.Configuration;
+
+public interface FreemarkerConfigurationFactory {
+
+    public Configuration getInstance();
+
+}

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerDefaultConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerDefaultConfigurationFactory.java
@@ -57,13 +57,16 @@ import jersey.repackaged.com.google.common.collect.Lists;
 
 
 /**
- * Handy {@link FreemarkerConfigurationFactory} that supplies a minimally configured
- * {@link freemarker.template.Configuration Configuration} able to create
- * {@link freemarker.template.Template Freemarker templates}.
- * The recommended method to provide custom Freemarker configuration is to sub-class this class,
- * register it with the {@link FreemarkerMvcFeature} TEMPLATE_OBJECT_FACTORY property,
- * and customize the {@link freemarker.template.Configuration configuration} in that class.
- * <p/>
+ * Handy {@link FreemarkerConfigurationFactory} that supplies a minimally
+ * configured {@link freemarker.template.Configuration Configuration} able to
+ * create {@link freemarker.template.Template Freemarker templates}.
+ * The recommended method to provide custom Freemarker configuration is to
+ * sub-class this class, further customize the
+ * {@link freemarker.template.Configuration configuration} as desired in that
+ * class, and then register the sub-class with the {@link FreemarkerMvcFeature}
+ * TEMPLATE_OBJECT_FACTORY property.
+ *
+ * @author Jeff Wilde (jeff.wilde at complicatedrobot.com)
  */
 public class FreemarkerDefaultConfigurationFactory implements FreemarkerConfigurationFactory {
 

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerDefaultConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerDefaultConfigurationFactory.java
@@ -46,7 +46,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import freemarker.cache.*;
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.FileTemplateLoader;
+import freemarker.cache.MultiTemplateLoader;
+import freemarker.cache.TemplateLoader;
+import freemarker.cache.WebappTemplateLoader;
 import freemarker.template.Configuration;
 import org.jvnet.hk2.annotations.Optional;
 import jersey.repackaged.com.google.common.collect.Lists;

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerDefaultConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerDefaultConfigurationFactory.java
@@ -1,0 +1,50 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.jersey.server.mvc.freemarker;
+
+
+import freemarker.template.Configuration;
+
+public class FreemarkerDefaultConfigurationFactory implements FreemarkerConfigurationFactory {
+    @Override
+    public Configuration getInstance() {
+        return null;
+    }
+}

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerDefaultConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerDefaultConfigurationFactory.java
@@ -40,11 +40,46 @@
 package org.glassfish.jersey.server.mvc.freemarker;
 
 
+import javax.inject.Inject;
+import javax.servlet.ServletContext;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import freemarker.cache.*;
 import freemarker.template.Configuration;
+import org.jvnet.hk2.annotations.Optional;
+import jersey.repackaged.com.google.common.collect.Lists;
 
 public class FreemarkerDefaultConfigurationFactory implements FreemarkerConfigurationFactory {
-    @Override
-    public Configuration getInstance() {
-        return null;
+
+    protected final Configuration configuration;
+
+    @Inject
+    public FreemarkerDefaultConfigurationFactory(@Optional final ServletContext servletContext) {
+        super();
+
+        // Create different loaders.
+        final List<TemplateLoader> loaders = Lists.newArrayList();
+        if (servletContext != null) {
+            loaders.add(new WebappTemplateLoader(servletContext));
+        }
+        loaders.add(new ClassTemplateLoader(FreemarkerDefaultConfigurationFactory.class, "/"));
+        try {
+            loaders.add(new FileTemplateLoader(new File("/")));
+        } catch (IOException e) {
+            // NOOP
+        }
+
+        // Create Base configuration.
+        configuration = new Configuration();
+        configuration.setTemplateLoader(new MultiTemplateLoader(loaders.toArray(new TemplateLoader[loaders.size()])));
+
     }
+
+    @Override
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
 }

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerMvcFeature.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerMvcFeature.java
@@ -89,17 +89,21 @@ public final class FreemarkerMvcFeature implements Feature {
     public static final String CACHE_TEMPLATES = MvcFeature.CACHE_TEMPLATES + SUFFIX;
 
     /**
-     * Property used to pass user-configured {@link freemarker.template.Configuration configuration} able to create
-     * {@link freemarker.template.Template Freemarker templates}.
+     * Property used to pass user-configured {@link org.glassfish.jersey.server.mvc.freemarker.FreemarkerConfigurationFactory}.
      * <p/>
      * The default value is not set.
      * <p/>
      * The name of the configuration property is <tt>{@value}</tt>.
      * <p/>
-     * If you want to set custom {@link freemarker.template.Configuration configuration} then set
+     * This property will also accept an instance of {@link freemarker.template.Configuration Configuration} directly, to support backwards
+     * compatibility. If you want to set custom {@link freemarker.template.Configuration configuration} then set
      * {@link freemarker.cache.TemplateLoader template loader} to multi loader of:
      * {@link freemarker.cache.WebappTemplateLoader} (if applicable), {@link freemarker.cache.ClassTemplateLoader} and
      * {@link freemarker.cache.FileTemplateLoader} keep functionality of resolving templates.
+     * <p/>
+     * If no value is set, a {@link org.glassfish.jersey.server.mvc.freemarker.FreemarkerDefaultConfigurationFactory factory} with the above behaviour
+     * is used by default in the {@link org.glassfish.jersey.server.mvc.freemarker.FreemarkerViewProcessor} class.
+     * <p/>
      *
      * @since 2.5
      */

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerMvcFeature.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerMvcFeature.java
@@ -53,6 +53,7 @@ import org.glassfish.jersey.server.mvc.MvcFeature;
  * Note: This feature also registers {@link MvcFeature}.
  *
  * @author Michal Gajdos (michal.gajdos at oracle.com)
+ * @author Jeff Wilde (jeff.wilde at complicatedrobot.com)
  */
 @ConstrainedTo(RuntimeType.SERVER)
 public final class FreemarkerMvcFeature implements Feature {

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerMvcFeature.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerMvcFeature.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2013-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerSuppliedConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerSuppliedConfigurationFactory.java
@@ -42,12 +42,23 @@ package org.glassfish.jersey.server.mvc.freemarker;
 
 import freemarker.template.Configuration;
 
-public class FreemarkerSuppliedConfigurationFactory implements FreemarkerConfigurationFactory {
+/**
+ * {@link FreemarkerConfigurationFactory} that supplies an unchanged
+ * {@link freemarker.template.Configuration Configuration} as passed-in to
+ * the constructor.
+ * <p/>
+ * Used to support backwards-compatibility in {@link FreemarkerViewProcessor}
+ * to wrap directly-configured {@link freemarker.template.Configuration Configuration}
+ * objects instead of the recommended {@link FreemarkerDefaultConfigurationFactory}
+ * or a sub-class thereof.
+ *
+ * @author Jeff Wilde (jeff.wilde at complicatedrobot.com)
+ */
+final class FreemarkerSuppliedConfigurationFactory implements FreemarkerConfigurationFactory {
 
-    protected final Configuration configuration;
+    private final Configuration configuration;
 
     public FreemarkerSuppliedConfigurationFactory(Configuration configuration) {
-        super();
         this.configuration = configuration;
     }
 

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerSuppliedConfigurationFactory.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerSuppliedConfigurationFactory.java
@@ -40,51 +40,15 @@
 package org.glassfish.jersey.server.mvc.freemarker;
 
 
-import javax.inject.Inject;
-import javax.servlet.ServletContext;
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
-import freemarker.cache.*;
 import freemarker.template.Configuration;
-import org.jvnet.hk2.annotations.Optional;
-import jersey.repackaged.com.google.common.collect.Lists;
 
-
-/**
- * Handy {@link FreemarkerConfigurationFactory} that supplies a minimally configured
- * {@link freemarker.template.Configuration Configuration} able to create
- * {@link freemarker.template.Template Freemarker templates}.
- * The recommended method to provide custom Freemarker configuration is to sub-class this class,
- * register it with the {@link FreemarkerMvcFeature} TEMPLATE_OBJECT_FACTORY property,
- * and customize the {@link freemarker.template.Configuration configuration} in that class.
- * <p/>
- */
-public class FreemarkerDefaultConfigurationFactory implements FreemarkerConfigurationFactory {
+public class FreemarkerSuppliedConfigurationFactory implements FreemarkerConfigurationFactory {
 
     protected final Configuration configuration;
 
-    @Inject
-    public FreemarkerDefaultConfigurationFactory(@Optional final ServletContext servletContext) {
+    public FreemarkerSuppliedConfigurationFactory(Configuration configuration) {
         super();
-
-        // Create different loaders.
-        final List<TemplateLoader> loaders = Lists.newArrayList();
-        if (servletContext != null) {
-            loaders.add(new WebappTemplateLoader(servletContext));
-        }
-        loaders.add(new ClassTemplateLoader(FreemarkerDefaultConfigurationFactory.class, "/"));
-        try {
-            loaders.add(new FileTemplateLoader(new File("/")));
-        } catch (IOException e) {
-            // NOOP
-        }
-
-        // Create Base configuration.
-        configuration = new Configuration();
-        configuration.setTemplateLoader(new MultiTemplateLoader(loaders.toArray(new TemplateLoader[loaders.size()])));
-
+        this.configuration = configuration;
     }
 
     @Override

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
@@ -72,6 +72,7 @@ import freemarker.template.TemplateException;
  *
  * @author Pavel Bucek (pavel.bucek at oracle.com)
  * @author Michal Gajdos (michal.gajdos at oracle.com)
+ * @author Jeff Wilde (jeff.wilde at complicatedrobot.com)
  */
 final class FreemarkerViewProcessor extends AbstractTemplateProcessor<Template> {
 

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
@@ -55,6 +55,7 @@ import javax.servlet.ServletContext;
 
 import freemarker.template.Configuration;
 import org.glassfish.jersey.internal.util.collection.Value;
+import org.glassfish.jersey.internal.util.collection.Values;
 import org.glassfish.jersey.server.ContainerException;
 import org.glassfish.jersey.server.mvc.Viewable;
 import org.glassfish.jersey.server.mvc.spi.AbstractTemplateProcessor;
@@ -94,12 +95,7 @@ final class FreemarkerViewProcessor extends AbstractTemplateProcessor<Template> 
         this.factory = getTemplateObjectFactory(serviceLocator, FreemarkerConfigurationFactory.class, new Value<FreemarkerConfigurationFactory>() {
             @Override
             public FreemarkerConfigurationFactory get() {
-                Configuration configuration = getTemplateObjectFactory(serviceLocator, Configuration.class, new Value<Configuration>() {
-                    @Override
-                    public Configuration get() {
-                        return null;
-                    }
-                });
+                Configuration configuration = getTemplateObjectFactory(serviceLocator, Configuration.class, Values.<Configuration>empty());
                 if (configuration == null) {
                     return new FreemarkerDefaultConfigurationFactory(servletContext);
                 } else {

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
@@ -90,8 +90,6 @@ final class FreemarkerViewProcessor extends AbstractTemplateProcessor<Template> 
                                    @Optional final ServletContext servletContext) {
         super(config, servletContext, "freemarker", "ftl");
 
-        ;
-
         this.factory = getTemplateObjectFactory(serviceLocator, FreemarkerConfigurationFactory.class, new Value<FreemarkerConfigurationFactory>() {
             @Override
             public FreemarkerConfigurationFactory get() {

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
@@ -64,7 +64,6 @@ import org.jvnet.hk2.annotations.Optional;
 
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import jersey.repackaged.com.google.common.collect.Lists;
 
 /**
  * {@link org.glassfish.jersey.server.mvc.spi.TemplateProcessor Template processor} providing support for Freemarker templates.

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2013-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
+++ b/ext/mvc-freemarker/src/main/java/org/glassfish/jersey/server/mvc/freemarker/FreemarkerViewProcessor.java
@@ -53,6 +53,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.inject.Inject;
 import javax.servlet.ServletContext;
 
+import freemarker.template.Configuration;
 import org.glassfish.jersey.internal.util.collection.Value;
 import org.glassfish.jersey.server.ContainerException;
 import org.glassfish.jersey.server.mvc.Viewable;
@@ -88,10 +89,22 @@ final class FreemarkerViewProcessor extends AbstractTemplateProcessor<Template> 
                                    @Optional final ServletContext servletContext) {
         super(config, servletContext, "freemarker", "ftl");
 
+        ;
+
         this.factory = getTemplateObjectFactory(serviceLocator, FreemarkerConfigurationFactory.class, new Value<FreemarkerConfigurationFactory>() {
             @Override
             public FreemarkerConfigurationFactory get() {
-                return new FreemarkerDefaultConfigurationFactory(servletContext);
+                Configuration configuration = getTemplateObjectFactory(serviceLocator, Configuration.class, new Value<Configuration>() {
+                    @Override
+                    public Configuration get() {
+                        return null;
+                    }
+                });
+                if (configuration == null) {
+                    return new FreemarkerDefaultConfigurationFactory(servletContext);
+                } else {
+                    return new FreemarkerSuppliedConfigurationFactory(configuration);
+                }
             }
         });
 


### PR DESCRIPTION
This pull request externalizes the freemarker Configuration instantiation code into a true factory class. 

The new code structure provides the following benefits: 
- makes it a lot easier to get a handle on the freemarker Configuration class before it is used by jersey
- simplifies the FreeMarkerViewProcessor class by externalizing the configuration setup in an external class
- makes it easy to reuse the jersey-specific Configuration setup (by simply extending the FreemarkerDefaultConfigurationFactory class)
- makes jersey's freemarker integration code structurally more similar to the mustache integration code

This would resolve [JERSEY-2771](https://java.net/jira/browse/JERSEY-2771).