### PR TITLE
Restore JarFileScanner support for parents with a trailing slash

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/JarFileScanner.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/JarFileScanner.java
@@ -75,7 +75,7 @@ public final class JarFileScanner implements ResourceFinder {
      */
     public JarFileScanner(final InputStream inputStream, final String parent, final boolean recursive) throws IOException {
         this.jarInputStream = new JarInputStream(inputStream);
-        this.parent = parent;
+        this.parent = (parent.isEmpty() || parent.endsWith(String.valueOf(JAR_FILE_SEPARATOR))) ? parent : parent + JAR_FILE_SEPARATOR;
         this.recursive = recursive;
     }
 
@@ -91,17 +91,8 @@ public final class JarFileScanner implements ResourceFinder {
                         break;
                     }
                     if (!next.isDirectory() && next.getName().startsWith(parent)) {
-                        final String suffix = next.getName().substring(parent.length());
-                        if (recursive) {
-                            // accept any entries with the prefix
-                            if (parent.isEmpty() || suffix.indexOf(JAR_FILE_SEPARATOR) == 0) {
-                                break;
-                            }
-                        } else {
-                            // accept only entries directly in the folder.
-                            if (suffix.lastIndexOf(JAR_FILE_SEPARATOR) == (parent.isEmpty() ? -1 : 0)) {
-                                break;
-                            }
+                        if (recursive || next.getName().substring(parent.length()).indexOf(JAR_FILE_SEPARATOR) == -1) {
+                            break;
                         }
                     }
                 } while (true);

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/JarFileScannerTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/JarFileScannerTest.java
@@ -108,6 +108,20 @@ public class JarFileScannerTest {
         assertThat("Failed to enumerate package 'javax.ws.rs' of javax.ws.rs-api", scannedEntries, equalTo(actualEntries));
     }
 
+    @Test
+    public void testRecursiveClassEnumerationWithOptionalTrailingSlash() throws IOException {
+        final int scannedEntriesWithoutSlash = countJarEntriesUsingScanner("javax/ws/rs", true);
+        final int scannedEntriesWithSlash = countJarEntriesUsingScanner("javax/ws/rs/", true);
+        assertThat("Adding a trailing slash incorrectly affects recursive scanning", scannedEntriesWithSlash, equalTo(scannedEntriesWithoutSlash));
+    }
+
+    @Test
+    public void testNonRecursiveClassEnumerationWithOptionalTrailingSlash() throws IOException {
+        final int scannedEntriesWithoutSlash = countJarEntriesUsingScanner("javax/ws/rs", false);
+        final int scannedEntriesWithSlash = countJarEntriesUsingScanner("javax/ws/rs/", false);
+        assertThat("Adding a trailing slash incorrectly affects recursive scanning", scannedEntriesWithSlash, equalTo(scannedEntriesWithoutSlash));
+    }
+
     private int countJarEntriesByPattern(final Pattern pattern) throws IOException {
         int matchingEntries = 0;
 


### PR DESCRIPTION
This is a follow up of #132. In that ticket @cguillot pointed out that as a side effect of the solution to #132, the `parent` parameter to `JarFileScanner` may no longer have a trailing slash. Since the `parent` parameter is clearly meant to be interpreted as a path component, I agree with @cguillot that this is a regression worth fixing.

This PR restores support for trailing slashes and adds two unit tests to prove it. As a side effect the `JarFileScanner` logic actually became quite a bit simpler.

As it stands, this PR introduces a small piece of conditional logic in the `JarFileScanner` constructor. If you prefer, I can also push this down into `#hasNext()` (at probably negligible performance cost).