### PR TITLE
Jersey 2625

### DIFF
--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/FieldProcessor.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/FieldProcessor.java
@@ -49,7 +49,6 @@ import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import javax.ws.rs.core.Link;
@@ -82,7 +81,7 @@ class FieldProcessor<T> {
      * @param uriInfo the uriInfo for the request
      */
     public void processLinks(T entity, UriInfo uriInfo, ResourceMappingContext rmc) {
-        Set<Object> processed = new HashSet<Object>(); //Collections.newSetFromMap(new IdentityHashMap<Object,Boolean>());
+        Set<Object> processed = new HashSet<Object>();
         Object resource = uriInfo.getMatchedResources().get(0);
         processLinks(entity, resource, entity, processed, uriInfo, rmc);
     }

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -747,7 +747,7 @@ public class FieldProcessorTest {
         {
             @Override
             public Iterator iterator() {
-                throw new RuntimeException("Something in the woodshed");
+                throw new RuntimeException("Declarative linking feature is incorrectly processing a transient interator");
             }
             
         };

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -747,7 +747,7 @@ public class FieldProcessorTest {
         {
             @Override
             public Iterator iterator() {
-                throw new RuntimeException("Declarative linking feature is incorrectly processing a transient interator");
+                throw new RuntimeException("Declarative linking feature is incorrectly processing a transient iterator");
             }
             
         };

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -43,6 +43,7 @@ package org.glassfish.jersey.linking;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Filter;
 import java.util.logging.LogRecord;
@@ -734,4 +735,30 @@ public class FieldProcessorTest {
         assertEquals(null, testClass.nested.link);
         assertEquals(null, testClass.transientNested.link);
     }
+
+
+
+ 
+    public static class TestClassN {
+        
+        // Simulate object injected by JPA
+        // in order to test a fix for JERSEY-2625
+        private transient Iterable res1 = new Iterable()
+        {
+            @Override
+            public Iterator iterator() {
+                throw new RuntimeException("Something in the woodshed");
+            }
+            
+        };
+    }
+
+    
+        @Test
+    public void testIgnoreTransient() {
+        TestClassN testClass = new TestClassN();
+        FieldProcessor<TestClassN> instance = new FieldProcessor(TestClassN.class);
+        instance.processLinks(testClass, mockUriInfo, mockRmc);
+    }
+
 }


### PR DESCRIPTION
A fix for issue JERSEY-2625, basically JPA was adding in a whole load of extra fields, the only way to really deal with this was to exclude all transient fields as they are not marked otherwise.

Whilst I was in there I also excluded a few other common cases such as String and primitive types in order to make things that much quicker.