### PR TITLE
change getClasses() impl to be non-final

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/ResourceConfig.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ResourceConfig.java
@@ -757,7 +757,7 @@ public class ResourceConfig extends Application implements Configurable<Resource
     }
 
     @Override
-    public final Set<Class<?>> getClasses() {
+    public Set<Class<?>> getClasses() {
         if (cachedClassesView == null) {
             cachedClasses = _getClasses();
             cachedClassesView = Collections.unmodifiableSet(cachedClasses);


### PR DESCRIPTION
It's verify difficult to find ways to hook into the Jersey application startup to prevent undesirable behaviors, such as when third party libs have classes annotated with `@Provider` and you want to prevent Jersey from registering them.

Things like making methods final in a library make it even more difficult to overcome these kinds of hurdles.

It would be nice to not have to completely hack everything to do something seemingly so simple