### PR TITLE
Fix typo of Tokenizer.

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/Tokenizer.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/Tokenizer.java
@@ -165,7 +165,7 @@ public final class Tokenizer {
      * @param entry a potentially quoted string entry.
      * @return a trimmed, unquoted string entry.
      */
-    public static String unqote(String entry) {
+    public static String unquote(String entry) {
         if (entry == null || entry.isEmpty()) {
             return entry;
         }

--- a/core-common/src/test/java/org/glassfish/jersey/internal/util/TokenizerTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/internal/util/TokenizerTest.java
@@ -91,18 +91,18 @@ public class TokenizerTest {
 
     @Test
     public void testUnqote() throws Exception {
-        assertEquals(null, Tokenizer.unqote(null));
-        assertEquals("", Tokenizer.unqote(""));
-        assertEquals("", Tokenizer.unqote("   "));
-        assertEquals("", Tokenizer.unqote("\"   "));
-        assertEquals("", Tokenizer.unqote(" \"\"  "));
-        assertEquals(" ", Tokenizer.unqote("\" \"  "));
-        assertEquals(" ", Tokenizer.unqote(" \" \"  "));
-        assertEquals("a b", Tokenizer.unqote(" \"a b\"  "));
-        assertEquals("a b", Tokenizer.unqote("\"a b\""));
-        assertEquals("a b", Tokenizer.unqote(" a b\"  "));
-        assertEquals("a b", Tokenizer.unqote("a b\""));
-        assertEquals("a b", Tokenizer.unqote(" \"a b  "));
-        assertEquals("a b", Tokenizer.unqote("\"a b"));
+        assertEquals(null, Tokenizer.unquote(null));
+        assertEquals("", Tokenizer.unquote(""));
+        assertEquals("", Tokenizer.unquote("   "));
+        assertEquals("", Tokenizer.unquote("\"   "));
+        assertEquals("", Tokenizer.unquote(" \"\"  "));
+        assertEquals(" ", Tokenizer.unquote("\" \"  "));
+        assertEquals(" ", Tokenizer.unquote(" \" \"  "));
+        assertEquals("a b", Tokenizer.unquote(" \"a b\"  "));
+        assertEquals("a b", Tokenizer.unquote("\"a b\""));
+        assertEquals("a b", Tokenizer.unquote(" a b\"  "));
+        assertEquals("a b", Tokenizer.unquote("a b\""));
+        assertEquals("a b", Tokenizer.unquote(" \"a b  "));
+        assertEquals("a b", Tokenizer.unquote("\"a b"));
     }
 }


### PR DESCRIPTION
In class org.glassfish.jersey.internal.util.Tokenizer, method _unquote_ is misspelled as _unqote_. The method name is now renamed and references in related test are changed as well.