### PR TITLE
Allow user of GrizzlyTestContainerFactory to configure the HttpServer

### DIFF
--- a/test-framework/providers/grizzly2/src/main/java/org/glassfish/jersey/test/grizzly/GrizzlyTestContainerFactory.java
+++ b/test-framework/providers/grizzly2/src/main/java/org/glassfish/jersey/test/grizzly/GrizzlyTestContainerFactory.java
@@ -71,7 +71,7 @@ public class GrizzlyTestContainerFactory implements TestContainerFactory {
 
         private final HttpServer server;
 
-        private GrizzlyTestContainer(final URI baseUri, final DeploymentContext context) {
+        private GrizzlyTestContainer(final URI baseUri, final DeploymentContext context, GrizzlyServerConfigurator configurator) {
             this.baseUri = UriBuilder.fromUri(baseUri).path(context.getContextPath()).build();
 
             if (LOGGER.isLoggable(Level.INFO)) {
@@ -80,6 +80,10 @@ public class GrizzlyTestContainerFactory implements TestContainerFactory {
             }
 
             this.server = GrizzlyHttpServerFactory.createHttpServer(this.baseUri, context.getResourceConfig(), false);
+
+            if(configurator != null) {
+               configurator.configureServer(this.server.getServerConfiguration());
+            }
         }
 
         @Override
@@ -127,6 +131,31 @@ public class GrizzlyTestContainerFactory implements TestContainerFactory {
 
     @Override
     public TestContainer create(final URI baseUri, final DeploymentContext context) {
-        return new GrizzlyTestContainer(baseUri, context);
+        return new GrizzlyTestContainer(baseUri, context, configurator);
+    }
+
+    private final GrizzlyServerConfigurator configurator;
+    public GrizzlyTestContainerFactory() {
+        this(null);
+    }
+
+    /**
+     * Create a custom GrizzlyTestContainerFactory which supports configuration of the
+     * Grizzly HttpServer instance
+     */
+    public GrizzlyTestContainerFactory(GrizzlyServerConfigurator configurator) {
+        this.configurator = configurator;
+    }
+
+    /**
+     * Allows custom configuration of a Grizzly HttpServer
+     */
+    public static interface GrizzlyServerConfigurator {
+        /**
+         * This is called right after the HttpServer has been created.
+         *
+         * @param grizzlyServerConfiguration
+         */
+        void configureServer(ServerConfiguration grizzlyServerConfiguration);
     }
 }


### PR DESCRIPTION
Using GrizzlyTestContainerFactory, it is not possible to configure the Grizzly HttpServer (for example, to call cfg.setAllowPayloadForUndefinedHttpMethods(true)).

This patch allows a unit test to specify custom configuration like this:
```

	@Override
	protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
		return new GrizzlyTestContainerFactory(new GrizzlyTestContainerFactory.GrizzlyServerConfigurator() {

			@Override
			public void configureServer(ServerConfiguration grizzlyServerConfiguration) {
				grizzlyServerConfiguration.setAllowPayloadForUndefinedHttpMethods(true);
			}
		});
	}
```
