### PR TITLE
FIX: oauth1-client excluding all non-POST 'application/x-www-form-urlencoded' form entity-body parameters from OAuth1 signature base string 

### DIFF
--- a/security/oauth1-client/src/main/java/org/glassfish/jersey/client/oauth1/RequestUtil.java
+++ b/security/oauth1-client/src/main/java/org/glassfish/jersey/client/oauth1/RequestUtil.java
@@ -46,7 +46,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URI;
 
-import javax.ws.rs.HttpMethod;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.GenericEntity;
@@ -92,8 +91,8 @@ final class RequestUtil {
 
     /**
      * Returns the form parameters from a request entity as a multi-valued map.
-     * If the request does not have a POST method, or the media type is not
-     * x-www-form-urlencoded, then null is returned.
+     * If the request does not have entity, or the media type is not
+     * x-www-form-urlencoded, empty map is returned.
      *
      * @param request the client request containing the entity to extract parameters from.
      * @return a {@link javax.ws.rs.core.MultivaluedMap} containing the entity form parameters.
@@ -106,9 +105,9 @@ final class RequestUtil {
         String method = request.getMethod();
         MediaType mediaType = request.getMediaType();
 
-        // no entity, not a post or not x-www-form-urlencoded: return empty map
-        if (entity == null || method == null || !HttpMethod.POST.equalsIgnoreCase(method)
-                || mediaType == null || !mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
+        // no entity or not x-www-form-urlencoded: return empty map
+        if (entity == null || method == null || mediaType == null ||
+                !MediaType.APPLICATION_FORM_URLENCODED_TYPE.equals(mediaType)) {
             return new MultivaluedHashMap<String, String>();
         }
 

--- a/security/oauth1-client/src/main/java/org/glassfish/jersey/client/oauth1/RequestUtil.java
+++ b/security/oauth1-client/src/main/java/org/glassfish/jersey/client/oauth1/RequestUtil.java
@@ -106,8 +106,8 @@ final class RequestUtil {
         MediaType mediaType = request.getMediaType();
 
         // no entity or not x-www-form-urlencoded: return empty map
-        if (entity == null || method == null || mediaType == null ||
-                !MediaType.APPLICATION_FORM_URLENCODED_TYPE.equals(mediaType)) {
+        if (entity == null || method == null
+                || !MediaType.APPLICATION_FORM_URLENCODED_TYPE.equals(mediaType)) {
             return new MultivaluedHashMap<String, String>();
         }
 


### PR DESCRIPTION
Jersey oauth1-client package did not handle the OAuth1 protocol  signature base string creation according to OAuth  1.0 Protocol RFC http://tools.ietf.org/html/rfc5849, resulting in incorrect signature for all non-GET and non-POST requests that include 'application/x-www-form-urlencoded' request entity body.

This error seems to stem from a very old oauth-core implementation and its description which said 
(http://oauth.net/core/1.0/#anchor14, section 9.1.1) [1]:
-----[1]----
 The request parameters are collected, sorted and concatenated into a normalized string:

    Parameters in the OAuth HTTP Authorization header excluding the realm parameter.
    Parameters in the HTTP POST request body (with a content-type of application/x-www-form-urlencoded).
    HTTP GET parameters added to the URLs in the query part (as defined by [RFC3986] section 3).
------[1]---

The message-thread from https://groups.google.com/d/msg/oauth/Qu9f7MVKfpo/bAWIOLGSTqUJ indicates this was erroneous. OAuth 1.0 protocol RFC http://tools.ietf.org/html/rfc5849#section-3.4.1.3.1 specifies the signature base string parameter source as follows [2]:

-----[2]-----
 The HTTP request entity-body, but only if all of the following
      conditions are met:

	* The entity-body is single-part.

	* The entity-body follows the encoding requirements of the
         "application/x-www-form-urlencoded" content-type as defined by
         [W3C.REC-html40-19980424].

	* The HTTP request entity-header includes the "Content-Type"
         header field set to "application/x-www-form-urlencoded".
----[2]-----


I discovered this bug while trying to get through my HTTP client generated PUT requests. Then I found that the signature base string generated only included the basics (method, url, query params, oauth params) and form entity was completely ignored.

With this fix I can talk PUT to server on the other side, and apparently other methods with entity bodies too.  This does not break any tests, b/c current tests only test GET/POST request signatures + correct parameter normalization ordering from Java type MultiValuedMap.

The changes were to RequestUtil which org.glassfish.jersey.oauth1.signature.OAuth1Request implementor org.glassfish.jersey.client.oauth1.Request.RequestWrapper uses to fetch params from wrapped request. Now it gets the  signature base string parameters from all HTTP request methods that have the content-type application/x-www-form-urlencoded and contain entity body.

It seems that Jersey Server signature verification is not affected by the same bug, as the 
org.glassfish.jersey.oauth1.signature.OAuth1Request implementor in the server package
org.glassfish.jersey.server.oauth1.internal.OAuthServerRequest does not discriminate 
based on HTTP request method when providing parameters for base string generation
before signature verification.