### PR TITLE
JERSEY-2690 & GLASSFISH-21114

### DIFF
--- a/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
+++ b/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
@@ -165,7 +165,7 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
             final List<String> tempLibNames = new LinkedList<>();
             for (ModuleInfo moduleInfo : appInfo.getModuleInfos()) {
                 final String jarName = moduleInfo.getName();
-                if (jarName.endsWith(".jar")) {
+                if (jarName.endsWith(".jar") || jarName.endsWith(".ear") || jarName.endsWith(".war")) {
                     final String moduleName = jarName.substring(0, jarName.length() - 4);
                     tempLibNames.add(moduleName);
                     final Object bundleDescriptor = moduleInfo.getMetaData(EjbBundleDescriptorImpl.class.getName());


### PR DESCRIPTION
This pull fixes an issue where EJBs are not injected correctly into modules which do not have the suffix ".jar".  Specifically this permits the use of the ".ear" and ".war" suffix.  

This logic should likely be re-evaluated as it may be missing any exautic module extensions.  But the requested pull does accurately fix the immediate issue.

Thanks,
