### PR TITLE
JERSEY-2863 Get values from uriInfo instead of having to declare them

### DIFF
--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/ELLinkBuilder.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/ELLinkBuilder.java
@@ -108,7 +108,7 @@ final class ELLinkBuilder {
         UriBuilder ub = applyLinkStyle(template, link.getLinkStyle(), uriInfo);
         UriTemplateParser parser = new UriTemplateParser(template);
         List<String> parameterNames = parser.getNames();
-        Map<String, Object> valueMap = getParameterValues(parameterNames, link, context);
+        Map<String, Object> valueMap = getParameterValues(parameterNames, link, context, uriInfo);
         return ub.buildFromMap(valueMap);
     }
 
@@ -131,24 +131,29 @@ final class ELLinkBuilder {
 
     private static Map<String, Object> getParameterValues(List<String> parameterNames,
                                                           InjectLinkDescriptor linkField,
-                                                          LinkELContext context) {
+                                                          LinkELContext context,
+                                                          UriInfo uriInfo) {
         Map<String, Object> values = new HashMap<>();
         for (String name : parameterNames) {
-            String elExpression = getEL(name, linkField);
+            String elExpression = linkField.getBinding(name);
+            if (elExpression == null) {
+                String value = uriInfo.getPathParameters().getFirst(name);
+                if (value == null) {
+                    value = uriInfo.getQueryParameters().getFirst(name);
+                }
+                if (value != null) {
+                    values.put(name, value);
+                    continue;
+                }
+                elExpression = "${" + ResponseContextResolver.INSTANCE_OBJECT + "." + name + "}";
+            }
             ValueExpression expr = expressionFactory.createValueExpression(context,
-                    elExpression, String.class);
+                        elExpression, String.class);
 
             Object value = expr.getValue(context);
             values.put(name, value != null ? value.toString() : null);
-        }
+         }
         return values;
     }
 
-    private static String getEL(String name, InjectLinkDescriptor linkField) {
-        String binding = linkField.getBinding(name);
-        if (binding != null) {
-            return binding;
-        }
-        return "${" + ResponseContextResolver.INSTANCE_OBJECT + "." + name + "}";
-    }
 }

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/HeaderProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/HeaderProcessorTest.java
@@ -49,6 +49,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.UriBuilder;
 
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.glassfish.jersey.linking.InjectLink.Extension;
 import org.glassfish.jersey.linking.mapping.ResourceMappingContext;
 import org.glassfish.jersey.server.ExtendedUriInfo;
@@ -114,19 +115,19 @@ public class HeaderProcessorTest {
         }
 
         public MultivaluedMap<String, String> getPathParameters() {
-            throw new UnsupportedOperationException("Not supported yet.");
+            return new MultivaluedStringMap();
         }
 
         public MultivaluedMap<String, String> getPathParameters(boolean decode) {
-            throw new UnsupportedOperationException("Not supported yet.");
+            return new MultivaluedStringMap();
         }
 
         public MultivaluedMap<String, String> getQueryParameters() {
-            throw new UnsupportedOperationException("Not supported yet.");
+            return new MultivaluedStringMap();
         }
 
         public MultivaluedMap<String, String> getQueryParameters(boolean decode) {
-            throw new UnsupportedOperationException("Not supported yet.");
+            return new MultivaluedStringMap();
         }
 
         public List<String> getMatchedURIs() {


### PR DESCRIPTION
This pre-populate the values needed by declarative linking to populate uris. It avoids the burden to declare the bindings and to expose the values in the instances.