### PR TITLE
JERSEY-2852: ClientResponse does not close ClosableHttpResponse

### DIFF
--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -437,7 +437,7 @@ class ApacheConnector implements Connector {
                     ? Statuses.from(response.getStatusLine().getStatusCode())
                     : Statuses.from(response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
 
-            final ClientResponse responseContext = new ClientResponse(status, clientRequest);
+            final ClientResponse responseContext = new ApacheConnectorClientResponse(status, clientRequest, response);
             final List<URI> redirectLocations = context.getRedirectLocations();
             if (redirectLocations != null && !redirectLocations.isEmpty()) {
                 responseContext.setResolvedRequestUri(redirectLocations.get(redirectLocations.size() - 1));

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnectorClientResponse.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnectorClientResponse.java
@@ -1,0 +1,52 @@
+package org.glassfish.jersey.apache.connector;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.StatusType;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.glassfish.jersey.client.ClientRequest;
+import org.glassfish.jersey.client.ClientResponse;
+
+/**
+ * Fix for https://github.com/docker-java/docker-java/issues/196
+ * 
+ * https://java.net/jira/browse/JERSEY-2852
+ * 
+ * @author marcus
+ * 
+ */
+public class ApacheConnectorClientResponse extends ClientResponse {
+
+	private CloseableHttpResponse closeableHttpResponse = null;
+
+	public ApacheConnectorClientResponse(ClientRequest requestContext,
+			Response response) {
+		super(requestContext, response);
+	}
+
+	public ApacheConnectorClientResponse(StatusType status,
+			ClientRequest requestContext,
+			CloseableHttpResponse closeableHttpResponse) {
+		super(status, requestContext);
+		this.closeableHttpResponse = closeableHttpResponse;
+	}
+
+	public ApacheConnectorClientResponse(StatusType status,
+			ClientRequest requestContext) {
+		super(status, requestContext);
+	}
+
+	@Override
+	public void close() {
+		if (closeableHttpResponse != null) {
+			try {
+				closeableHttpResponse.close();
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		super.close();
+	}
+}


### PR DESCRIPTION
This fixes https://java.net/jira/browse/JERSEY-2852 

Please review and merge. Thanks!