### PR TITLE
hashCode() fix

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -380,7 +380,8 @@ public final class WebResourceFactory implements InvocationHandler {
 
     @Override
     public int hashCode() {
-        //every call to static "WebResourceFactory.newResource(...)" creates a new instance of WebResourceFactory internally ==> unique hashCode
+        //every call to static "WebResourceFactory.newResource(...)" creates
+        //a new instance of WebResourceFactory internally ==> unique hashCode
         return super.hashCode();
     }
 

--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -163,6 +163,10 @@ public final class WebResourceFactory implements InvocationHandler {
             return toString();
         }
 
+        if (args == null && method.getName().equals("hashCode")) {
+            return hashCode();
+        }
+
         // get the interface describing the resource
         final Class<?> proxyIfc = proxy.getClass().getInterfaces()[0];
 
@@ -372,6 +376,12 @@ public final class WebResourceFactory implements InvocationHandler {
     @Override
     public String toString() {
         return target.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        //every call to static "WebResourceFactory.newResource(...)" creates a new instance of WebResourceFactory internally ==> unique hashCode
+        return super.hashCode();
     }
 
     private static String getHttpMethodName(final AnnotatedElement ae) {

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -342,4 +342,10 @@ public class WebResourceFactoryTest extends JerseyTest {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    public void testHashCode() throws Exception {
+        resource.hashCode();
+        //no thrown UnsupportedOperationException ==> everything is ok
+    }
 }


### PR DESCRIPTION
IoC-ecosystem like Spring keep track of the beans to manage in a map or collection. A lot of implementations of collection/map use "hashCode()" of item to store. This causes trouble with the WebResourceFactory, as it throws a "UnsupportedOperationException" saying that its missing a @Path on the method name "hashCode()".

The method "toString()" is already excluded by the proxy and I would like to add the "hashCode()" method.
