### PR TITLE
JERSEY-2880: Link HTTP Header: Headers may contain double-quote-less parameters.

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/LinkProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/LinkProvider.java
@@ -106,9 +106,13 @@ public class LinkProvider implements HeaderDelegateProvider<Link> {
                     checkToken(st, ";");
                     String n = st.nextToken().trim();
                     checkToken(st, "=");
-                    checkToken(st, "\"");
-                    String v = st.nextToken();
-                    checkToken(st, "\"");
+
+                    String v = nextNonEmptyToken(st);
+                    if (v.equals("\"")) {
+                        v = st.nextToken();
+                        checkToken(st, "\"");
+                    }
+
                     lb.param(n, v);
                 }
             }
@@ -122,6 +126,17 @@ public class LinkProvider implements HeaderDelegateProvider<Link> {
             throw new IllegalArgumentException("Unable to parse link " + value);
         }
         return lb;
+    }
+
+    private static String nextNonEmptyToken(StringTokenizer st) throws IllegalArgumentException {
+        String token = null;
+        do {
+            token = st.nextToken().trim();
+        } while (token.length() == 0);
+        if (token == null) {
+            throw new IllegalArgumentException("Non-Empty token not found");
+        }
+        return token;
     }
 
     private static void checkToken(StringTokenizer st, String expected) throws IllegalArgumentException {

--- a/core-common/src/test/java/org/glassfish/jersey/message/internal/LinkProviderTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/message/internal/LinkProviderTest.java
@@ -118,4 +118,12 @@ public class LinkProviderTest {
         Link l2 = Link.valueOf("<http://example.org/app/link1>; foo1=\"bar1\"; foo2 = \"bar2\"");
         assertEquals(l1, l2);
     }
+
+    @Test
+    public void testWithoutDoubleQuotes() {
+        Link l1 = Link.fromUri("http://example.org/app/link1").param("foo1", "bar1").param("foo2", "bar2").build();
+        assertEquals(l1, Link.valueOf(l1.toString()));
+        Link l2 = Link.valueOf("<http://example.org/app/link1>; foo1=bar1; foo2 = bar2");
+        assertEquals(l1, l2);
+    }
 }


### PR DESCRIPTION
Please see http://tools.ietf.org/html/rfc5988#section-5
which permits rel, rev, type and many more being without double quotes.

The jersey client doesn't accept valid server responses without this change.

See https://java.net/jira/browse/JERSEY-2880 for the according issue.