### PR TITLE
JERSEY-2881: jdk1.7+ Profile Prevents Dependency Resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -869,7 +869,7 @@
         <profile>
             <id>jdk1.7+</id>
             <activation>
-                <jdk>[1.7,</jdk>
+                <jdk>[1.7,)</jdk>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
fixed the syntax error on activation: jdk >= 1.7 causing build error with following message :
Invalid JDK version in profile 'jdk1.7+': Unbounded range: [1.7, for project org.glassfish.jersey:project