### PR TITLE
JERSEY-2636: POST requests without Content-Type header pass through @…

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/MethodSelectingRouter.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/MethodSelectingRouter.java
@@ -234,7 +234,8 @@ final class MethodSelectingRouter implements Router {
          */
         boolean isConsumable(ContainerRequest requestContext) {
             MediaType contentType = requestContext.getMediaType();
-            return contentType == null || consumes.getMediaType().isCompatible(contentType);
+            return consumes.getMediaType().isCompatible(contentType)
+                    || (contentType == null && MediaType.WILDCARD_TYPE.equals(consumes.getMediaType()));
         }
 
         @Override

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/inject/FormParamTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/inject/FormParamTest.java
@@ -440,6 +440,37 @@ public class FormParamTest extends AbstractTest {
         assertEquals("POST", responseContext.getEntity());
     }
 
+    @Path("/")
+    public static class ConsumesApplicationFormUrlEncoded {
+
+        @POST
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        public String post(@FormParam("foo") final String foo) {
+            assertEquals("bar", foo);
+            return "OK";
+        }
+
+    }
+
+    /**
+     * JERSEY-2636: POST requests without Content-Type header pass through @Consumes check
+     */
+    @Test
+    public void testConsumesMatching() throws Exception {
+        testConsumesMatching("application/x-www-form-urlencoded", 200);
+        testConsumesMatching("text/plain", 415);
+        testConsumesMatching(null, 415);
+    }
+
+    private void testConsumesMatching(final String contentType, final int expectedStatus) throws Exception {
+        initiateWebApplication(ConsumesApplicationFormUrlEncoded.class);
+        final Form form = new Form("foo", "bar");
+        final ContainerResponse response = apply(
+                RequestContextBuilder.from("/", "POST").type(contentType).entity(form).build()
+        );
+        assertEquals(expectedStatus, response.getStatus());
+    }
+
 //    @InjectParam replace with @Inject?
 
 //    public static class ParamBean {

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/routing/ResponseMediaTypeFromProvidersTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/routing/ResponseMediaTypeFromProvidersTest.java
@@ -109,6 +109,6 @@ public class ResponseMediaTypeFromProvidersTest {
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo("text/plain"));
-        assertThat((String) response.getEntity(), equalTo("AnotherSubResource"));
+        assertThat((String) response.getEntity(), equalTo("AnotherSubResourceAnotherSubResource"));
     }
 }

--- a/core-server/src/test/java/org/glassfish/jersey/server/model/AsyncContentAndEntityTypeTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/model/AsyncContentAndEntityTypeTest.java
@@ -110,7 +110,7 @@ public class AsyncContentAndEntityTypeTest {
         ContainerResponse response;
         // making sure the JVM optimization does not swap the order of the calls.
         synchronized (this) {
-            app.apply(RequestContextBuilder.from("/", "POST").entity("Foo").build());
+            app.apply(RequestContextBuilder.from("/", "POST").type("application/foo").entity("Foo").build());
             response = responseFuture.get();
         }
 

--- a/core-server/src/test/java/org/glassfish/jersey/server/model/ConsumeProduceSimpleTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/model/ConsumeProduceSimpleTest.java
@@ -114,7 +114,6 @@ public class ConsumeProduceSimpleTest {
     }
 
     @Path("/{arg1}/{arg2}")
-    @Consumes("text/html")
     @Produces("text/html")
     public static class ConsumeProduceSimpleBean {
 
@@ -135,6 +134,7 @@ public class ConsumeProduceSimpleTest {
         }
 
         @POST
+        @Consumes("text/html")
         @SuppressWarnings("UnusedParameters")
         public String doPostHtml(String data) {
             assertEquals("text/html", httpHeaders.getRequestHeader("Content-Type").get(0));


### PR DESCRIPTION
…Consumes check.

Three scenarios below have different behavior before/after this change:

@Consumes                         | Request Content-Type              | Old Result | New Result
----------------------------------+-----------------------------------+------------+-----------
text/plain                        | text/plain                        | 200        | 200
text/plain                        | image/jpeg                        | 415        | 415
text/plain                        | -                                 | 200        | 415
*/*                               | text/plain                        | 200        | 200
*/*                               | image/jpeg                        | 200        | 200
*/*                               | -                                 | 200        | 200
multipart/form-data               | multipart/form-data               | 200        | 200
multipart/form-data               | text/plain                        | 415        | 415
multipart/form-data               | image/jpeg                        | 415        | 415
multipart/form-data               | -                                 | 500        | 415
application/x-www-form-urlencoded | application/x-www-form-urlencoded | 200        | 200
application/x-www-form-urlencoded | text/plain                        | 415        | 415
application/x-www-form-urlencoded | image/jpeg                        | 415        | 415
application/x-www-form-urlencoded | -                                 | 500        | 415