### PR TITLE
JERSEY-2895: Log bad request reason.

### DIFF
--- a/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/WebComponent.java
+++ b/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/WebComponent.java
@@ -409,6 +409,9 @@ public class WebComponent {
                 }
             });
         } catch (final HeaderValueException hve) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Bad resuest: " + hve.getMessage());
+            }
             final Response.Status status = Response.Status.BAD_REQUEST;
             if (configSetStatusOverSendError) {
                 servletResponse.reset();


### PR DESCRIPTION
Due to recent upgrade from jersey1 to jersey2, we found out that Jersey actually eats the exception information when the request header is invalid. This normally is fine but the information from the `HeaderValueException` contains  valuable information for debugging purpose and should not be simply discarded. 

This PR simply log the error message with `FINE` level. 