### PR TITLE
Handle second and subsequent requests for a null value in RequestScope

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/process/internal/RequestScope.java
+++ b/core-common/src/main/java/org/glassfish/jersey/process/internal/RequestScope.java
@@ -158,7 +158,7 @@ public class RequestScope implements Context<RequestScoped> {
         final Instance instance = current();
 
         U retVal = instance.get(activeDescriptor);
-        if (retVal == null) {
+        if (retVal == null && !instance.hasDescriptor(activeDescriptor)) {
             retVal = activeDescriptor.create(root);
             instance.put(activeDescriptor, retVal);
         }
@@ -498,6 +498,17 @@ public class RequestScope implements Context<RequestScoped> {
         @SuppressWarnings("unchecked")
         <T> T get(ActiveDescriptor<T> descriptor) {
             return (T) store.get(descriptor);
+        }
+
+        /**
+         * Checks whether an inhabitant is currently stored that matches the given descriptor.
+         *
+         * @param descriptor inhabitant descriptor.
+         * @return true if the instance contains an inhabitant matching this descriptor, false
+         *         otherwise.
+         */
+        boolean hasDescriptor(ActiveDescriptor<?> descriptor) {
+            return store.containsKey(descriptor);
         }
 
         /**

--- a/core-common/src/test/java/org/glassfish/jersey/process/internal/RequestScopeTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/process/internal/RequestScopeTest.java
@@ -186,16 +186,36 @@ public class RequestScopeTest {
         assertNull(instance.get(inhab));
     }
 
+    @Test
+    public void testGetNullTwice() {
+        final RequestScope requestScope = new RequestScope();
+        assertNull(requestScope.suspendCurrent());
+        final Instance instance = requestScope.createInstance();
+        final TestProvider inhab = new TestProvider("a", null);
+        requestScope.runInScope(instance, new Runnable() {
+            @Override
+            public void run() {
+                assertNull(requestScope.findOrCreate(inhab, null));
+                // This should not crash:
+                assertNull(requestScope.findOrCreate(inhab, null));
+            }
+        });
+    }
+
     /**
      * Test request scope inhabitant.
      */
     public static class TestProvider extends AbstractActiveDescriptor<String> {
 
-        private final String id;
+        private final String id, value;
 
-        public TestProvider(final String id) {
-            super();
+        public TestProvider(String id) {
+            this(id, id);
+        }
+
+        public TestProvider(final String id, final String value) {
             this.id = id;
+            this.value = value;
         }
 
         @Override
@@ -205,7 +225,7 @@ public class RequestScopeTest {
 
         @Override
         public String create(final ServiceHandle<?> root) {
-            return id;
+            return value;
         }
     }
 }


### PR DESCRIPTION
This solves an error I see in Jersey applications when attempting to inject a null ```@RequestScoped``` value in two separate locations.

I am currently investigating whether my company has an existing OCA or whether I will need to sign one individually.