### PR TITLE
FIX: oauth1-server excluding all 'application/x-www-form-urlencoded' requests with Content-Type parameters from OAuth1 signature base string

### DIFF
--- a/security/oauth1-server/src/main/java/org/glassfish/jersey/server/oauth1/internal/OAuthServerRequest.java
+++ b/security/oauth1-server/src/main/java/org/glassfish/jersey/server/oauth1/internal/OAuthServerRequest.java
@@ -55,6 +55,7 @@ import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.glassfish.jersey.message.internal.MediaTypes;
 import org.glassfish.jersey.internal.util.collection.Value;
 import org.glassfish.jersey.internal.util.collection.Values;
 import org.glassfish.jersey.oauth1.signature.OAuth1Request;
@@ -80,7 +81,7 @@ public class OAuthServerRequest implements OAuth1Request {
                 public MultivaluedMap<String, String> get() {
                     MultivaluedMap<String, String> params = null;
                     final MediaType mediaType = context.getMediaType();
-                    if (mediaType != null && mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
+                    if (mediaType != null && MediaTypes.typeEqual(mediaType, MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
                         final ContainerRequest jerseyRequest = (ContainerRequest) context;
                         jerseyRequest.bufferEntity();
                         final Form form = jerseyRequest.readEntity(Form.class);


### PR DESCRIPTION
There is an issue with the oauth1-server package that is not treating requests with a content type like `application/x-www-form-urlencoded; charset=UTF-8`.

I've added a fix to remove the parameters comparison to check if a request is a `x-www-form-urlencoded` request or not.
