### PR TITLE
JERSEY-2928: declarative-linking: @BeanParam linking support

### DIFF
--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkFieldDescriptor.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkFieldDescriptor.java
@@ -166,29 +166,7 @@ class InjectLinkFieldDescriptor extends FieldDescriptor implements InjectLinkDes
                         builder.append(methodTemplate);
                     }
 
-                    // append query parameters
-                    StringBuilder querySubString = new StringBuilder();
-                    int index = 0;
-                    for (Annotation paramAnns[] : method.getParameterAnnotations()) {
-                        for (Annotation ann : paramAnns) {
-                            if (ann.annotationType() == QueryParam.class) {
-                                querySubString.append(((QueryParam) ann).value());
-                                querySubString.append(',');
-                            }
-                            if (ann.annotationType() == BeanParam.class) {
-                                Class<?> beanParamType = method.getParameterTypes()[index];
-                                Field fields[] = beanParamType.getFields();
-                                for (Field field : fields) {
-                                    QueryParam queryParam = field.getAnnotation(QueryParam.class);
-                                    if (queryParam != null) {
-                                        querySubString.append(queryParam.value());
-                                        querySubString.append(',');
-                                    }
-                                }
-                            }
-                        }
-                        index++;
-                    }
+                    StringBuilder querySubString = extractQueryParams(method);
 
                     if (querySubString.length() > 0) {
                         builder.append("{?");
@@ -205,6 +183,33 @@ class InjectLinkFieldDescriptor extends FieldDescriptor implements InjectLinkDes
         }
 
         return template;
+    }
+
+    private static StringBuilder extractQueryParams(AnnotatedMethod method) throws SecurityException {
+        // append query parameters
+        StringBuilder querySubString = new StringBuilder();
+        int index = 0;
+        for (Annotation paramAnns[] : method.getParameterAnnotations()) {
+            for (Annotation ann : paramAnns) {
+                if (ann.annotationType() == QueryParam.class) {
+                    querySubString.append(((QueryParam) ann).value());
+                    querySubString.append(',');
+                }
+                if (ann.annotationType() == BeanParam.class) {
+                    Class<?> beanParamType = method.getParameterTypes()[index];
+                    Field fields[] = beanParamType.getFields();
+                    for (Field field : fields) {
+                        QueryParam queryParam = field.getAnnotation(QueryParam.class);
+                        if (queryParam != null) {
+                            querySubString.append(queryParam.value());
+                            querySubString.append(',');
+                        }
+                    }
+                }
+            }
+            index++;
+        }
+        return querySubString;
     }
 
     /**

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkFieldDescriptor.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkFieldDescriptor.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.ws.rs.BeanParam;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
@@ -167,13 +168,26 @@ class InjectLinkFieldDescriptor extends FieldDescriptor implements InjectLinkDes
 
                     // append query parameters
                     StringBuilder querySubString = new StringBuilder();
+                    int index = 0;
                     for (Annotation paramAnns[] : method.getParameterAnnotations()) {
                         for (Annotation ann : paramAnns) {
                             if (ann.annotationType() == QueryParam.class) {
                                 querySubString.append(((QueryParam) ann).value());
                                 querySubString.append(',');
                             }
+                            if (ann.annotationType() == BeanParam.class) {
+                                Class<?> beanParamType = method.getParameterTypes()[index];
+                                Field fields[] = beanParamType.getFields();
+                                for (Field field : fields) {
+                                    QueryParam queryParam = field.getAnnotation(QueryParam.class);
+                                    if (queryParam != null) {
+                                        querySubString.append(queryParam.value());
+                                        querySubString.append(',');
+                                    }
+                                }
+                            }
                         }
+                        index++;
                     }
 
                     if (querySubString.length() > 0) {

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkFieldDescriptor.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinkFieldDescriptor.java
@@ -42,6 +42,7 @@ package org.glassfish.jersey.linking;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -188,7 +189,7 @@ class InjectLinkFieldDescriptor extends FieldDescriptor implements InjectLinkDes
     private static StringBuilder extractQueryParams(AnnotatedMethod method) throws SecurityException {
         // append query parameters
         StringBuilder querySubString = new StringBuilder();
-        int index = 0;
+        int parameterIndex = 0;
         for (Annotation paramAnns[] : method.getParameterAnnotations()) {
             for (Annotation ann : paramAnns) {
                 if (ann.annotationType() == QueryParam.class) {
@@ -196,7 +197,7 @@ class InjectLinkFieldDescriptor extends FieldDescriptor implements InjectLinkDes
                     querySubString.append(',');
                 }
                 if (ann.annotationType() == BeanParam.class) {
-                    Class<?> beanParamType = method.getParameterTypes()[index];
+                    Class<?> beanParamType = method.getParameterTypes()[parameterIndex];
                     Field fields[] = beanParamType.getFields();
                     for (Field field : fields) {
                         QueryParam queryParam = field.getAnnotation(QueryParam.class);
@@ -205,9 +206,17 @@ class InjectLinkFieldDescriptor extends FieldDescriptor implements InjectLinkDes
                             querySubString.append(',');
                         }
                     }
+                    Method beanMethods[] = beanParamType.getMethods();
+                    for (Method beanMethod : beanMethods) {
+                        QueryParam queryParam = beanMethod.getAnnotation(QueryParam.class);
+                        if (queryParam != null) {
+                            querySubString.append(queryParam.value());
+                            querySubString.append(',');
+                        }
+                    }
                 }
             }
-            index++;
+            parameterIndex++;
         }
         return querySubString;
     }

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/mapping/NaiveResourceMappingContext.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/mapping/NaiveResourceMappingContext.java
@@ -65,7 +65,7 @@ import org.glassfish.jersey.uri.UriTemplate;
 
 /**
  * This implementation of the resource mapping context assumed resource are
- * of simple a simple type with a statically defined structure.
+ * of a simple type with a statically defined structure.
  *
  * @author Gerard Davison (gerard.davison at oracle.com)
  */

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -50,6 +50,7 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.regex.MatchResult;
 import java.util.zip.ZipEntry;
+import javax.ws.rs.BeanParam;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -686,6 +687,48 @@ public class FieldProcessorTest {
         assertEquals("/application/resources/a/b?query=queryExample&query2=queryExample2", testClass.uri);
         //clean mock
         mockUriInfo.getQueryParameters().clear();
+    }
+
+    public static class BeanParamBean {
+        @QueryParam("query") public String query;
+    }
+
+    @Path("a")
+    public static class BeanParamQueryResource {
+
+        @Path("b")
+        @GET
+        public String getB(@BeanParam BeanParamBean beanParamBean) {
+            return "hello world";
+        }
+    }
+
+    public static class BeanParamResourceBean {
+
+        public String getQueryParam() {
+            return queryExample;
+        }
+
+        private String queryExample;
+
+        public BeanParamResourceBean(String queryExample) {
+            this.queryExample = queryExample;
+        }
+
+        @InjectLink(resource = BeanParamQueryResource.class, method = "getB",
+                bindings = {
+                        @Binding(name = "query", value = "${instance.queryParam}")
+                })
+        public String uri;
+    }
+
+    @Test
+    public void testBeanParamResource() {
+        LOG.info("BeanParamResource");
+        FieldProcessor<BeanParamResourceBean> instance = new FieldProcessor(BeanParamResourceBean.class);
+        BeanParamResourceBean testClass = new BeanParamResourceBean("queryExample");
+        instance.processLinks(testClass, mockUriInfo, mockRmc);
+        assertEquals("/application/resources/a/b?query=queryExample", testClass.uri);
     }
 
     public static class TestClassK {

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -689,7 +689,16 @@ public class FieldProcessorTest {
         mockUriInfo.getQueryParameters().clear();
     }
 
-    public static class BeanParamBean {
+    /** Bean param with method setter QueryParam. */
+    public static class BeanParamBeanA {
+        private String qparam;
+        @QueryParam("qparam") public void setQParam(String qparam) {
+            this.qparam = qparam;
+        }
+    }
+
+    /** Bean param with field QueryParam. */
+    public static class BeanParamBeanB {
         @QueryParam("query") public String query;
     }
 
@@ -698,7 +707,7 @@ public class FieldProcessorTest {
 
         @Path("b")
         @GET
-        public String getB(@BeanParam BeanParamBean beanParamBean) {
+        public String getB(@BeanParam BeanParamBeanA beanParamBeanA, @BeanParam BeanParamBeanB beanParamBeanB) {
             return "hello world";
         }
     }
@@ -717,7 +726,8 @@ public class FieldProcessorTest {
 
         @InjectLink(resource = BeanParamQueryResource.class, method = "getB",
                 bindings = {
-                        @Binding(name = "query", value = "${instance.queryParam}")
+                        @Binding(name = "query", value = "${instance.queryParam}"),
+                        @Binding(name = "qparam", value = "foo")
                 })
         public String uri;
     }
@@ -728,7 +738,7 @@ public class FieldProcessorTest {
         FieldProcessor<BeanParamResourceBean> instance = new FieldProcessor(BeanParamResourceBean.class);
         BeanParamResourceBean testClass = new BeanParamResourceBean("queryExample");
         instance.processLinks(testClass, mockUriInfo, mockRmc);
-        assertEquals("/application/resources/a/b?query=queryExample", testClass.uri);
+        assertEquals("/application/resources/a/b?query=queryExample&qparam=foo", testClass.uri);
     }
 
     public static class TestClassK {


### PR DESCRIPTION
The declarative-linking feature has no support for the @BeanParam annotation.
This pull request changes it at least for @QueryParams in the beans' fields and setters.

See also https://java.net/jira/browse/JERSEY-2928