### PR TITLE
JERSEY-2928: declarative-linking: @BeanParam linking support

### DIFF
--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinksFieldDescriptor.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLinksFieldDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -50,6 +50,7 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.regex.MatchResult;
 import java.util.zip.ZipEntry;
+import javax.ws.rs.BeanParam;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -686,6 +687,58 @@ public class FieldProcessorTest {
         assertEquals("/application/resources/a/b?query=queryExample&query2=queryExample2", testClass.uri);
         //clean mock
         mockUriInfo.getQueryParameters().clear();
+    }
+
+    /** Bean param with method setter QueryParam. */
+    public static class BeanParamBeanA {
+        private String qparam;
+        @QueryParam("qparam") public void setQParam(String qparam) {
+            this.qparam = qparam;
+        }
+    }
+
+    /** Bean param with field QueryParam. */
+    public static class BeanParamBeanB {
+        @QueryParam("query") public String query;
+    }
+
+    @Path("a")
+    public static class BeanParamQueryResource {
+
+        @Path("b")
+        @GET
+        public String getB(@BeanParam BeanParamBeanA beanParamBeanA, @BeanParam BeanParamBeanB beanParamBeanB) {
+            return "hello world";
+        }
+    }
+
+    public static class BeanParamResourceBean {
+
+        public String getQueryParam() {
+            return queryExample;
+        }
+
+        private String queryExample;
+
+        public BeanParamResourceBean(String queryExample) {
+            this.queryExample = queryExample;
+        }
+
+        @InjectLink(resource = BeanParamQueryResource.class, method = "getB",
+                bindings = {
+                        @Binding(name = "query", value = "${instance.queryParam}"),
+                        @Binding(name = "qparam", value = "foo")
+                })
+        public String uri;
+    }
+
+    @Test
+    public void testBeanParamResource() {
+        LOG.info("BeanParamResource");
+        FieldProcessor<BeanParamResourceBean> instance = new FieldProcessor(BeanParamResourceBean.class);
+        BeanParamResourceBean testClass = new BeanParamResourceBean("queryExample");
+        instance.processLinks(testClass, mockUriInfo, mockRmc);
+        assertEquals("/application/resources/a/b?qparam=foo&query=queryExample", testClass.uri);
     }
 
     public static class TestClassK {

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/FieldProcessorTest.java
@@ -692,7 +692,8 @@ public class FieldProcessorTest {
     /** Bean param with method setter QueryParam. */
     public static class BeanParamBeanA {
         private String qparam;
-        @QueryParam("qparam") public void setQParam(String qparam) {
+        @QueryParam("qparam")
+        public void setQParam(String qparam) {
             this.qparam = qparam;
         }
     }


### PR DESCRIPTION
The declarative-linking feature has no support for the [@BeanParam](https://jax-rs-spec.java.net/nonav/2.0-SNAPSHOT/apidocs/javax/ws/rs/BeanParam.html) annotation.
This pull request changes it at least for @QueryParams in the beans' fields and setters.

See also https://java.net/jira/browse/JERSEY-2928