### PR TITLE
JERSEY-2978: StringIndexOutOfBoundsException thrown from UriTemplateParser

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/uri/internal/UriTemplateParser.java
+++ b/core-common/src/main/java/org/glassfish/jersey/uri/internal/UriTemplateParser.java
@@ -53,6 +53,8 @@ import java.util.regex.PatternSyntaxException;
 import org.glassfish.jersey.internal.LocalizationMessages;
 import org.glassfish.jersey.uri.UriComponent;
 
+import jersey.repackaged.com.google.common.net.UrlEscapers;
+
 /**
  * A URI template parser that parses JAX-RS specific URI templates.
  *
@@ -278,13 +280,15 @@ public class UriTemplateParser {
                 if (RESERVED_REGEX_CHARACTERS.contains(c)) {
                     regex.append("\\");
                     regex.append(c);
-                } else if (c == '%') {
+                } else if (c == '%' && s.length() >= (i + 2)) {
                     final char c1 = s.charAt(i + 1);
                     final char c2 = s.charAt(i + 2);
                     if (UriComponent.isHexCharacter(c1) && UriComponent.isHexCharacter(c2)) {
                         regex.append("%").append(HEX_TO_UPPERCASE_REGEX[c1]).append(HEX_TO_UPPERCASE_REGEX[c2]);
-                        i += 2;
+                    } else {
+                        regex.append("%").append(c1).append(c2);
                     }
+                    i += 2;
                 } else {
                     regex.append(c);
                 }

--- a/core-common/src/test/java/org/glassfish/jersey/uri/UriTemplateTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/uri/UriTemplateTest.java
@@ -348,18 +348,14 @@ public class UriTemplateTest {
     
     @Test
     public void testSpecificCharacterPosition() {
-        _testSpecificCharacterPosition("/test/coverage/100%", 
-                                       "/test/coverage/100%");
-        _testSpecificCharacterPosition("/test/coverrage/100%/done", 
-                                       "/test/coverrage/100%/done");
-        _testSpecificCharacterPosition("/test/coverrage/100%26done", 
-                                       "/test/coverrage/100%26done");
-        _testSpecificCharacterPosition("/test/coverrage/100%;today", 
-                                       "/test/coverrage/100%;today");
+        _testSpecificCharacterPosition("/test/coverage/100%"); 
+        _testSpecificCharacterPosition("/test/coverrage/100%/done");
+        _testSpecificCharacterPosition("/test/coverrage/100%26done");
+        _testSpecificCharacterPosition("/test/coverrage/100%;today");
     }
 
-    private void _testSpecificCharacterPosition(String uri, String expected) {
-        assertEquals(expected, new UriTemplate(uri).getPattern().getRegex());
+    private void _testSpecificCharacterPosition(String uri) {
+        assertEquals(uri, new UriTemplate(uri).getPattern().getRegex());
     }
 
     @Test

--- a/core-common/src/test/java/org/glassfish/jersey/uri/UriTemplateTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/uri/UriTemplateTest.java
@@ -39,6 +39,12 @@
  */
 package org.glassfish.jersey.uri;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,13 +56,7 @@ import java.util.Map;
 import java.util.regex.MatchResult;
 
 import org.glassfish.jersey.uri.internal.UriTemplateParser;
-
 import org.junit.Test;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Taken from Jersey 1: jersey-tests: com.sun.jersey.impl.uri.UriTemplateTest
@@ -344,6 +344,22 @@ public class UriTemplateTest {
                 l.get(2).getTemplate());
         assertEquals(UriTemplate.EMPTY.getTemplate(),
                 l.get(3).getTemplate());
+    }
+    
+    @Test
+    public void testSpecificCharacterPosition() {
+        _testSpecificCharacterPosition("/test/coverage/100%", 
+                                       "/test/coverage/100%");
+        _testSpecificCharacterPosition("/test/coverrage/100%/done", 
+                                       "/test/coverrage/100%/done");
+        _testSpecificCharacterPosition("/test/coverrage/100%26done", 
+                                       "/test/coverrage/100%26done");
+        _testSpecificCharacterPosition("/test/coverrage/100%;today", 
+                                       "/test/coverrage/100%;today");
+    }
+
+    private void _testSpecificCharacterPosition(String uri, String expected) {
+        assertEquals(expected, new UriTemplate(uri).getPattern().getRegex());
     }
 
     @Test


### PR DESCRIPTION
i try to fix https://java.net/jira/browse/JERSEY-2978 

this problem occur when call from org.glassfish.jersey.linking.ELLinkBuilder (109) of declarative-linking project. 
please review.