### PR TITLE
Extended properties for MappedJettison wrapper

### DIFF
--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/Stax2JettisonFactory.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/Stax2JettisonFactory.java
@@ -49,6 +49,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.glassfish.jersey.jettison.JettisonConfig;
+import org.glassfish.jersey.jettison.JettisonConfig.Mapped;
 import org.glassfish.jersey.message.internal.ReaderWriter;
 
 import org.codehaus.jettison.badgerfish.BadgerFishXMLStreamReader;
@@ -77,16 +78,12 @@ public class Stax2JettisonFactory {
             case BADGERFISH:
                 return new BadgerFishXMLStreamWriter(writer);
             case MAPPED_JETTISON:
-                Configuration jmConfig;
-                if (null == config.getXml2JsonNs()) {
-                    jmConfig = new Configuration();
-                } else {
-                    jmConfig = new Configuration(config.getXml2JsonNs());
-                }
+                JettisonConfig.Mapped mapped = (JettisonConfig.Mapped) config;
+                Configuration jmConfig = createMappedConfig(mapped);
 
                 final MappedXMLStreamWriter result = new MappedXMLStreamWriter(new MappedNamespaceConvention(jmConfig), writer);
 
-                for (String array : config.getArrayElements()) {
+                for (String array : mapped.getArrayElements()) {
                     result.serializeAsArray(array);
                 }
 
@@ -94,6 +91,23 @@ public class Stax2JettisonFactory {
             default:
                 return null;
         }
+    }
+    private static Configuration createMappedConfig(JettisonConfig.Mapped mapped) {
+         Configuration jmConfig = new Configuration();
+         jmConfig.setAttributeKey(mapped.getAttributeKey());
+         jmConfig.setAttributesAsElements(mapped.getAttributesAsElements());
+         jmConfig.setDropRootElement(mapped.isDropRootElement());
+         jmConfig.setEscapeForwardSlashAlways(mapped.isEscapeForwardSlashAlways());
+         jmConfig.setIgnoredElements(mapped.getIgnoredElements());
+         jmConfig.setIgnoreEmptyArrayValues(mapped.isIgnoreEmptyArrayValues());
+         jmConfig.setIgnoreNamespaces(mapped.isIgnoreNamespaces());
+         jmConfig.setJsonNamespaceSeparator(mapped.getJsonNamespaceSeparator());
+         jmConfig.setPrimitiveArrayKeys(mapped.getPrimitiveArrayKeys());
+         jmConfig.setReadNullAsString(mapped.isReadNullAsString());
+         jmConfig.setSupressAtAttributes(mapped.isSupressAtAttributes());
+         jmConfig.setWriteNullAsString(mapped.isWriteNullAsString());
+         jmConfig.setXmlToJsonNamespaces(mapped.getXml2JsonNs());
+         return jmConfig;
     }
 
     public static XMLStreamReader createReader(final Reader reader,
@@ -103,12 +117,8 @@ public class Stax2JettisonFactory {
         switch (config.getNotation()) {
             case MAPPED_JETTISON:
                 try {
-                    Configuration jmConfig;
-                    if (null == config.getXml2JsonNs()) {
-                        jmConfig = new Configuration();
-                    } else {
-                        jmConfig = new Configuration(config.getXml2JsonNs());
-                    }
+                    JettisonConfig.Mapped mapped = (JettisonConfig.Mapped) config;
+                    Configuration jmConfig = createMappedConfig(mapped);
                     return new MappedXMLStreamReader(
                             new JSONObject(new JSONTokener(ReaderWriter.readFromAsString(nonEmptyReader))),
                             new MappedNamespaceConvention(jmConfig));


### PR DESCRIPTION
Hi,

I would like to marshal JAXB JSON but without the root element wrapper as discussed in:
http://stackoverflow.com/questions/18417466/jaxb-remove-xmlrootelement-wrapper/18421298#18421298

I am using Jettison as my JAXB provider, unfortunately this is  not supported.
I have extended the JettisonConfig wrapper to include more properties to make this possible. 
I am now able to unmarshal without the root element wrapper using a context resolver such as:  

        public final class JaxbContextResolver implements ContextResolver<JAXBContext> {

            private final JAXBContext context;
            private final Set<Class<?>> types;
            private final Class<?>[] cTypes = {Flights.class, FlightType.class, AircraftType.class};

            public JaxbContextResolver() throws Exception {
            	System.out.println("Injected JaxbContextResolver");
                this.types = new HashSet<Class<?>>(Arrays.asList(cTypes));
                //this.context = new JettisonJaxbContext(JettisonConfig.DEFAULT, cTypes);
                this.context = new JettisonJaxbContext(JettisonConfig.mappedJettison().setDropRootElement(true).build(), cTypes);
            }

            @Override
            public JAXBContext getContext(Class<?> objectType) {
                return (types.contains(objectType)) ? context : null;
            }
        }