### PR TITLE
JERSEY-3023: Client proxy not marshalling object to json due to order…

### DIFF
--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
@@ -42,6 +42,7 @@ package org.glassfish.jersey.client.proxy;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
 
 import java.util.List;
 import java.util.Set;
@@ -185,5 +186,20 @@ public class MyResource implements MyResourceIfc {
     @Override
     public String putIt(MyBean dummyBean) {
         return headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
+    }
+
+    @Override
+    public MyBean entityAndSecurityContext(MyBean bean, SecurityContext sc) {
+        return bean;
+    }
+
+    @Override
+    public MyBean securityContextAndEntity(SecurityContext sc, MyBean bean) {
+        return bean;
+    }
+
+    @Override
+    public MyBean headerAndEntityAndSecurityContext(String header, MyBean bean, SecurityContext sc) {
+        return bean;
     }
 }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
@@ -58,6 +58,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
 
 @Path("myresource")
 public interface MyResourceIfc {
@@ -194,4 +195,23 @@ public interface MyResourceIfc {
     @PUT
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     String putIt(MyBean dummyBean);
+
+    @Path("entity-index-1")
+    @POST
+    @Produces(MediaType.APPLICATION_XML)
+    @Consumes(MediaType.APPLICATION_XML)
+    MyBean entityAndSecurityContext(MyBean bean, @Context SecurityContext sc);
+
+    @Path("entity-index-2")
+    @POST
+    @Produces(MediaType.APPLICATION_XML)
+    @Consumes(MediaType.APPLICATION_XML)
+    MyBean securityContextAndEntity(@Context SecurityContext sc, MyBean bean);
+
+    @Path("entity-index-3")
+    @POST
+    @Produces(MediaType.APPLICATION_XML)
+    @Consumes(MediaType.APPLICATION_XML)
+    MyBean headerAndEntityAndSecurityContext(@HeaderParam("Content-Type") String header, MyBean bean,
+            @Context SecurityContext sc);
 }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryEntityIndexTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryEntityIndexTest.java
@@ -1,0 +1,143 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2012-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.jersey.client.proxy;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * Tests for https://java.net/jira/browse/JERSEY-3023 fix (work-around).
+ *
+ * The overloaded factory methods for {@code WebResourceFactory} allows
+ * the developer to pass the resource method parameter index of the entity
+ * if necessary.
+ */
+public class WebResourceFactoryEntityIndexTest extends JerseyTest {
+
+    private static final String NAME = "Jersey";
+
+    final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<String, Object>() {
+        {
+            add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML);
+        }
+    };
+    final List<Cookie> cookies = Collections.<Cookie>emptyList();
+
+    @Override
+    protected ResourceConfig configure() {
+        // mvn test -Djersey.config.test.container.factory=org.glassfish.jersey.test.inmemory.InMemoryTestContainerFactory
+        // mvn test -Djersey.config.test.container.factory=org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory
+        // mvn test -Djersey.config.test.container.factory=org.glassfish.jersey.test.jdkhttp.JdkHttpServerTestContainerFactory
+        // mvn test -Djersey.config.test.container.factory=org.glassfish.jersey.test.simple.SimpleTestContainerFactory
+        enable(TestProperties.LOG_TRAFFIC);
+        enable(TestProperties.DUMP_ENTITY);
+        return new ResourceConfig(MyResource.class);
+    }
+
+    /**
+     * <pre>
+     *  MyBean entityAndSecurityContext(MyBean bean, @Context SecurityContext sc);
+     * </pre>
+     */
+    @Test
+    public void testEntityAndSecurityContext() {
+        final MyBean bean = new MyBean();
+        bean.name = NAME;
+        final int entityIndex = 0;
+        MyResourceIfc resource = WebResourceFactory.newResource(
+                MyResourceIfc.class, target(), false, headers, cookies, new Form(), entityIndex);
+        assertEquals(NAME, resource.entityAndSecurityContext(bean, null).name);
+
+        resource = WebResourceFactory.newResource(MyResourceIfc.class, target(), entityIndex);
+        assertEquals(NAME, resource.entityAndSecurityContext(bean, null).name);
+    }
+
+    /**
+     * <pre>
+     *  MyBean securityContextAndEntity(@Context SecurityContext sc, MyBean bean);
+     * </pre>
+     */
+    @Test
+    public void testSecurityContextAndEntity() {
+        final MyBean bean = new MyBean();
+        bean.name = NAME;
+        final int entityIndex = 1;
+        MyResourceIfc resource = WebResourceFactory.newResource(
+                MyResourceIfc.class, target(), false, headers, cookies, new Form(), entityIndex);
+        assertEquals(NAME, resource.securityContextAndEntity(null, bean).name);
+
+        resource = WebResourceFactory.newResource(MyResourceIfc.class, target(), entityIndex);
+        assertEquals(NAME, resource.securityContextAndEntity(null, bean).name);
+    }
+
+    /**
+     * <pre>
+     *  MyBean headerAndEntityAndSecurityContext(@HeaderParam("Content-Type") String header,
+     *                                           MyBean bean,
+     *                                           @Context SecurityContext sc);
+     * </pre>
+     */
+    @Test
+    public void testHeaderAndEntityAndSecurityContext() {
+        final MyBean bean = new MyBean();
+        bean.name = NAME;
+        final int entityIndex = 1;
+        MyResourceIfc resource = WebResourceFactory.newResource(
+                MyResourceIfc.class, target(), false, headers, cookies, new Form(), entityIndex);
+        assertEquals(NAME, resource.headerAndEntityAndSecurityContext(null, bean, null).name);
+
+        resource = WebResourceFactory.newResource(MyResourceIfc.class, target(), entityIndex);
+        assertEquals(NAME, resource.headerAndEntityAndSecurityContext(null, bean, null).name);
+    }
+}


### PR DESCRIPTION
**JERSEY-3023: Client proxy not marshalling object to json due to order of arguments**

The original algorithm for creating the resource proxy loops through all the method parameters
and checks if the parameter contains an `@XxxParam` annotation. If it doesn't,
then it is determined to be the entity parameter. The problem with this is that
it doesn't take into account `@Context` and other possible annotation
that are not the entity, so the entity needs to always be the last parameter
in the event there are other parameters without `@XxxParam`.

There's not really much you can do about this, as the possibilities are limitless
as to what could cause a fault in this algorithm. A reasonable solution
(or maybe work around) this PR proposes is to just allow the developer to specify the entity
index explicitly in an overloaded factory method. Without using the overload,
this solution leaves the program to proceed as it normally would, so there is no 
effect to any previous usages.

Tests were added to verify the behavior of the entity index, in the test class
`WebResourceFactoryEntityIndexTest`.

Another thing I'd like to mention is that I added some documentation for the client proxy. I created it in a different branch, as I wasn't sure if this is something that should be part a different issue/PR. [This is the branch](https://github.com/psamsotha/jersey/tree/client-proxy-docs) that includes the documentation. What I added is appended to the end of the Client API documentation, as I felt this was the most appropriate location. I'd like to contribute this piece of documentation if it is satisfactory.
