### PR TITLE
JERSEY-3042: Resource scanning inefficient

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/model/Resource.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/Resource.java
@@ -48,6 +48,7 @@ import java.util.Set;
 
 import javax.ws.rs.Path;
 
+import jersey.repackaged.com.google.common.collect.ArrayListMultimap;
 import org.glassfish.jersey.Severity;
 import org.glassfish.jersey.internal.Errors;
 import org.glassfish.jersey.internal.util.collection.Value;
@@ -564,22 +565,27 @@ public final class Resource implements Routed, ResourceModelComponent {
         }
 
         private List<Resource.Data> mergeResources(List<Resource.Data> resources) {
-            List<Resource.Data> mergedResources = Lists.newArrayList();
-            for (int i = 0; i < resources.size(); i++) {
-                Resource.Data outer = resources.get(i);
+            //Separate out the Resources by their path
+            final ArrayListMultimap<String, Resource.Data> resourceMap = ArrayListMultimap.create();
+            for (final Resource.Data resource : resources){
+                resourceMap.put(resource.path, resource);
+            }
+
+            final List<Resource.Data> mergedResources = Lists.newArrayList();
+
+            //Merge resources with matching paths
+            for (final String key : resourceMap.keySet()) {
+                final List<Resource.Data> resourcesForPath = resourceMap.get(key);
+                final Resource.Data outer = resourcesForPath.get(0);
                 Resource.Builder builder = null;
-
-                for (int j = i + 1; j < resources.size(); j++) {
-                    Resource.Data inner = resources.get(j);
-
-                    if (outer.path.equals(inner.path)) {
+                if (resourcesForPath.size() > 1) {
+                    final List<Resource.Data> remainingResources = resourcesForPath.subList(1, resourcesForPath.size());
+                    for (final Iterator<Resource.Data> iterator = remainingResources.iterator(); iterator.hasNext(); ) {
+                        final Resource.Data inner = iterator.next();
                         if (builder == null) {
                             builder = Resource.builder(outer);
                         }
                         builder.mergeWith(inner);
-                        resources.remove(j);
-                        //noinspection AssignmentToForLoopParameter
-                        j--;
                     }
                 }
                 if (builder == null) {


### PR DESCRIPTION
This patch improves the performance of Resource merging when there are
large numbers of Resources with the same path. The runtime of the
mergeResources method has been greatly improved when there are > 100
matching paths, since the nested loop and element removals were refactored
out.