### PR TITLE
Fix bug causing hints to be printed as warnings.

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/Errors.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/Errors.java
@@ -178,7 +178,7 @@ public class Errors {
                         warnings.append(LocalizationMessages.WARNING_MSG(error.getMessage())).append('\n');
                         break;
                     case HINT:
-                        warnings.append(LocalizationMessages.HINT_MSG(error.getMessage())).append('\n');
+                        hints.append(LocalizationMessages.HINT_MSG(error.getMessage())).append('\n');
                         break;
                 }
             }


### PR DESCRIPTION
Seems like a copy-paste bug.