### PR TITLE
Set syncFlush to true in GZipEncoder, DeflateEncoder

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/DeflateEncoder.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/DeflateEncoder.java
@@ -122,7 +122,7 @@ public class DeflateEncoder extends ContentEncoder {
         }
 
         return deflateWithoutZLib
-                ? new DeflaterOutputStream(entityStream, new Deflater(Deflater.DEFAULT_COMPRESSION, true))
-                : new DeflaterOutputStream(entityStream);
+                ? new DeflaterOutputStream(entityStream, new Deflater(Deflater.DEFAULT_COMPRESSION, true), true)
+                : new DeflaterOutputStream(entityStream, true);
     }
 }

--- a/core-common/src/main/java/org/glassfish/jersey/message/GZipEncoder.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/GZipEncoder.java
@@ -76,6 +76,6 @@ public class GZipEncoder extends ContentEncoder {
     @Override
     public OutputStream encode(String contentEncoding, OutputStream entityStream)
             throws IOException {
-        return new GZIPOutputStream(entityStream);
+        return new GZIPOutputStream(entityStream, true);
     }
 }


### PR DESCRIPTION
This allows HTTP streaming protocols, like SSE, to operate properly
without buffering effects, by allowing OutputStream.flush() to flush
the compression buffer of any pending data.

Targets JERSEY-3037 (was closed as "Works as designed", but I hope I'm not alone in hoping that SSE and compression aren't mutually exclusive).