### PR TITLE
JERSEY-3008: Allow adding headers to OutboundEvent

### DIFF
--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEvent.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEvent.java
@@ -43,6 +43,7 @@ import java.lang.reflect.Type;
 
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 
@@ -61,6 +62,7 @@ public final class OutboundEvent {
     private final MediaType mediaType;
     private final Object data;
     private final long reconnectDelay;
+    private final MultivaluedMap<String, Object> eventHeaders;
 
     /**
      * Used for creating {@link OutboundEvent} instances.
@@ -74,6 +76,7 @@ public final class OutboundEvent {
         private GenericType type;
         private Object data;
         private MediaType mediaType = MediaType.TEXT_PLAIN_TYPE;
+        private MultivaluedMap<String, Object> eventHeaders;
 
         /**
          * Set event name.
@@ -241,6 +244,22 @@ public final class OutboundEvent {
         }
 
         /**
+         * Set any additional headers to be attached to the event.
+         *
+         * @param eventHeaders HTTP headers to add
+         * @return updated builder instance.
+         * @throws NullPointerException in case the {@code eventHeaders} parameter is {@code null}.
+         */
+        public Builder headers(MultivaluedMap<String, Object> eventHeaders) {
+            if (eventHeaders == null) {
+                throw new NullPointerException(LocalizationMessages.OUT_EVENT_DATA_NULL());
+            }
+
+            this.eventHeaders = eventHeaders;
+            return this;
+        }
+
+        /**
          * Build {@link OutboundEvent}.
          * <p>
          * There are two valid configurations:
@@ -261,7 +280,7 @@ public final class OutboundEvent {
                 throw new IllegalStateException(LocalizationMessages.OUT_EVENT_NOT_BUILDABLE());
             }
 
-            return new OutboundEvent(name, id, reconnectDelay, type, mediaType, data, comment);
+            return new OutboundEvent(name, id, reconnectDelay, type, mediaType, data, comment, eventHeaders);
         }
     }
 
@@ -282,7 +301,8 @@ public final class OutboundEvent {
                   final GenericType type,
                   final MediaType mediaType,
                   final Object data,
-                  final String comment) {
+                  final String comment,
+                  final MultivaluedMap<String, Object> eventHeaders) {
         this.name = name;
         this.comment = comment;
         this.id = id;
@@ -290,6 +310,7 @@ public final class OutboundEvent {
         this.type = type;
         this.mediaType = mediaType;
         this.data = data;
+        this.eventHeaders = eventHeaders;
     }
 
     /**
@@ -408,5 +429,9 @@ public final class OutboundEvent {
      */
     public Object getData() {
         return data;
+    }
+
+    public MultivaluedMap<String, Object> getHeaders() {
+        return eventHeaders;
     }
 }

--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
@@ -132,6 +132,9 @@ class OutboundEventWriter implements MessageBodyWriter<OutboundEvent> {
                     outboundEvent.getMediaType() == null ? MediaType.TEXT_PLAIN_TYPE : outboundEvent.getMediaType();
             final MessageBodyWriter messageBodyWriter = workersProvider.get().getMessageBodyWriter(outboundEvent.getType(),
                     outboundEvent.getGenericType(), annotations, eventMediaType);
+            if (outboundEvent.getHeaders() != null && !outboundEvent.getHeaders().isEmpty()) {
+                httpHeaders.putAll(outboundEvent.getHeaders());
+            }
             messageBodyWriter.writeTo(
                     outboundEvent.getData(),
                     outboundEvent.getType(),

--- a/media/sse/src/test/java/org/glassfish/jersey/media/sse/OutboundEventTest.java
+++ b/media/sse/src/test/java/org/glassfish/jersey/media/sse/OutboundEventTest.java
@@ -40,10 +40,14 @@
 package org.glassfish.jersey.media.sse;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 
@@ -150,5 +154,16 @@ public class OutboundEventTest {
         assertEquals(ArrayList.class, ReflectionHelper.erasure(event.getGenericType()));
         assertEquals(new GenericEntity<ArrayList<String>>(new ArrayList<String>()) {
         }.getType(), event.getGenericType());
+    }
+
+    @Test
+    public void testHeaders() throws Exception {
+        OutboundEvent event;
+
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>(1);
+        headers.put("Access-Control-Allow-Origin", Collections.singletonList("*"));
+        event = new OutboundEvent.Builder().headers(headers).build();
+
+        assertEquals(headers, event.getHeaders());
     }
 }


### PR DESCRIPTION
This is a very simple, naïve attempt at fixing [JERSEY-3008](https://java.net/jira/browse/JERSEY-3008). The issue should explain the motivation behind wanting to be able to add headers directly to an `OutboundEvent` (for my specific needs I would use this to add a CORS header).

Any feedback would be greatly appreciated.
