### PR TITLE
Fixes Jersey 3113

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/inject/SingleValueExtractor.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/inject/SingleValueExtractor.java
@@ -39,12 +39,12 @@
  */
 package org.glassfish.jersey.server.internal.inject;
 
+import org.glassfish.jersey.internal.inject.ExtractorException;
+
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.ParamConverter;
-
-import org.glassfish.jersey.internal.inject.ExtractorException;
 
 /**
  * Extract value of the parameter using a single parameter value and the underlying
@@ -81,7 +81,9 @@ final class SingleValueExtractor<T> extends AbstractParamValueExtractor<T> imple
     public T extract(final MultivaluedMap<String, String> parameters) {
         final String value = parameters.getFirst(getName());
         try {
-            return fromString((value == null && isDefaultValueRegistered()) ? getDefaultValueString() : value);
+            String val = (value == null && isDefaultValueRegistered()) ? getDefaultValueString() : value;
+            if (val == null) return null;
+            return fromString(val);
         } catch (final WebApplicationException | ProcessingException ex) {
             throw ex;
         } catch (final IllegalArgumentException ex) {


### PR DESCRIPTION
This fixes how jersey handles optionals on multipart form for JAXBObjects.  Since not all parts are required in a form this allows Jersey and applications to handle this more gracefully.  Currently this is throwing a NullPointerException at a layer below the application layer.