### PR TITLE
File upload is broken with IE 11 and Edge: Backslashes in Content-Disposition filename

### DIFF
--- a/media/multipart/src/main/java/org/glassfish/jersey/media/multipart/internal/MultiPartReaderClientSide.java
+++ b/media/multipart/src/main/java/org/glassfish/jersey/media/multipart/internal/MultiPartReaderClientSide.java
@@ -226,6 +226,7 @@ public class MultiPartReaderClientSide implements MessageBodyReader<MultiPart> {
             // if so, need to set fileNameFix to true to handle issue http://java.net/jira/browse/JERSEY-759
             final String userAgent = headers.getFirst(HttpHeaders.USER_AGENT);
             // The above "feature" seems to be present in IE11 and Edge also
+            // See issue https://java.net/jira/browse/JERSEY-3159
             fileNameFix = userAgent != null && (userAgent.contains(" MSIE ") || userAgent.contains("Trident/") || userAgent.contains("Edge/"));
         }
 

--- a/media/multipart/src/main/java/org/glassfish/jersey/media/multipart/internal/MultiPartReaderClientSide.java
+++ b/media/multipart/src/main/java/org/glassfish/jersey/media/multipart/internal/MultiPartReaderClientSide.java
@@ -225,7 +225,8 @@ public class MultiPartReaderClientSide implements MessageBodyReader<MultiPart> {
             // see if the User-Agent header corresponds to some version of MS Internet Explorer
             // if so, need to set fileNameFix to true to handle issue http://java.net/jira/browse/JERSEY-759
             final String userAgent = headers.getFirst(HttpHeaders.USER_AGENT);
-            fileNameFix = userAgent != null && userAgent.contains(" MSIE ");
+            // The above "feature" seems to be present in IE11 and Edge also
+            fileNameFix = userAgent != null && (userAgent.contains(" MSIE ") || userAgent.contains("Trident/") || userAgent.contains("Edge/"));
         }
 
         for (final MIMEPart mimePart : getMimeParts(mimeMessage)) {


### PR DESCRIPTION
Copied from https://java.net/jira/browse/JERSEY-3159

IE11 and Microsoft Edge both still send non-standard conforming filename:

    -----------------------------7db13314200d0
    Content-Disposition: form-data; name="file"; filename="C:\tmp\test.txt"
    Content-Type: application/octet-stream

What my application gets when reading the filename is `"C:tmptest.txt"`
This could be fixed like the original issue by matching the User-Agent by adding matching for `"Trident/"` and `"Edge/"`