### PR TITLE
JERSEY-1653: Add support for @BeanParam in jersey-proxy-client

### DIFF
--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParam.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParam.java
@@ -1,0 +1,73 @@
+package org.glassfish.jersey.client.proxy;
+
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * @author Lucas Sa
+ */
+public class MyBeanParam {
+    @QueryParam("name") private String queryName;
+
+    @CookieParam("name") private  String cookieName;
+
+    @HeaderParam("name") private String headerName;
+
+    private String setterQueryName;
+
+    private String setterCookieName;
+
+    private String setterHeaderName;
+
+    public String getQueryName() {
+        return queryName;
+    }
+
+    public void setQueryName(String queryName) {
+        this.queryName = queryName;
+    }
+
+    public String getCookieName() {
+        return cookieName;
+    }
+
+    public void setCookieName(String cookieName) {
+        this.cookieName = cookieName;
+    }
+
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    public void setHeaderName(String headerName) {
+        this.headerName = headerName;
+    }
+
+    public String getSetterQueryName() {
+        return setterQueryName;
+    }
+
+    @QueryParam("setterName")
+    public void setSetterQueryName(String setterQueryName) {
+        this.setterQueryName = setterQueryName;
+    }
+
+    public String getSetterCookieName() {
+        return setterCookieName;
+    }
+
+    @CookieParam("setterName")
+    public void setSetterCookieName(String setterCookieName) {
+        this.setterCookieName = setterCookieName;
+    }
+
+    public String getSetterHeaderName() {
+        return setterHeaderName;
+    }
+
+    @HeaderParam("setterName")
+    public void setSetterHeaderName(String setterHeaderName) {
+        this.setterHeaderName = setterHeaderName;
+    }
+}

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
@@ -39,6 +39,7 @@
  */
 package org.glassfish.jersey.client.proxy;
 
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -89,6 +90,12 @@ public class MyResource implements MyResourceIfc {
     @Override
     public String getByNameMatrix(String name) {
         return name;
+    }
+
+    @Override
+    public String getByBean(@BeanParam MyBeanParam bean) {
+        return bean.getQueryName() + bean.getCookieName() + bean.getHeaderName()
+                + bean.getSetterQueryName() + bean.getSetterCookieName() + bean.getSetterHeaderName();
     }
 
     @Override

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.FormParam;
@@ -100,6 +101,11 @@ public interface MyResourceIfc {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     String getByNameMatrix(@MatrixParam("matrix-name") String name);
+
+    @Path("bean")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    String getByBean(@BeanParam MyBeanParam bean);
 
     @Path("form")
     @POST

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -143,6 +143,19 @@ public class WebResourceFactoryTest extends JerseyTest {
     }
 
     @Test
+    public void testBeanParam() {
+        MyBeanParam bean = new MyBeanParam();
+        bean.setQueryName("Query");
+        bean.setCookieName("Cookie");
+        bean.setHeaderName("Header");
+        bean.setSetterQueryName("SetterQuery");
+        bean.setSetterCookieName("SetterCookie");
+        bean.setSetterHeaderName("SetterHeader");
+        assertEquals("QueryCookieHeaderSetterQuerySetterCookieSetterHeader",
+            resource.getByBean(bean));
+    }
+
+    @Test
     public void testSubResource() {
         assertEquals("Got it!", resource.getSubResource().getMyBean().name);
     }


### PR DESCRIPTION
This pull requests adds support to implement proxy clients on resources that use JAX-RS `@BeanParam` annotation.

Main change is introduced in the new method `extractParamsFromBeanParamClass()` that handle bean class info. Most of the rest is moving logic from the main invoke procedure to separate method for reuse.

I'm creating this on 2.x branch so it is released as part of future Jersey 2 releases, but I think the extension is exactly the same on master now.