### PR TITLE
RankedComparator reordering equal values fix

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/model/internal/RankedComparator.java
+++ b/core-common/src/main/java/org/glassfish/jersey/model/internal/RankedComparator.java
@@ -85,7 +85,7 @@ public class RankedComparator<T> implements Comparator<RankedProvider<T>> {
 
     @Override
     public int compare(final RankedProvider<T> o1, final RankedProvider<T> o2) {
-        return ((getPriority(o1) > getPriority(o2)) ? order.ordering : -order.ordering);
+        return getPriority(o1) == getPriority(o2) ? 0 : getPriority(o1) > getPriority(o2) ? order.ordering : -order.ordering;
     }
 
     protected int getPriority(final RankedProvider<T> rankedProvider) {

--- a/core-common/src/test/java/org/glassfish/jersey/process/internal/RankedComparatorTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/process/internal/RankedComparatorTest.java
@@ -50,6 +50,8 @@ import org.glassfish.jersey.model.internal.RankedComparator;
 import org.glassfish.jersey.model.internal.RankedProvider;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -88,6 +90,20 @@ public class RankedComparatorTest {
             assertTrue(val <= max);
             max = val;
         }
+    }
+
+    @Test
+    public void testEqualPrioritiesComparator() {
+        List<RankedProvider<Object>> list = new LinkedList<>();
+        list.add(new RankedProvider<Object>(new F200()));
+        list.add(new RankedProvider<Object>(new FF200()));
+        List<RankedProvider<Object>> copy = new LinkedList<>(list);
+
+        Collections.sort(list, new RankedComparator<Object>(RankedComparator.Order.ASCENDING));
+        assertEquals(copy, list);
+
+        Collections.sort(list, new RankedComparator<Object>(RankedComparator.Order.DESCENDING));
+        assertEquals(copy, list);
     }
 
     @Priority(0)


### PR DESCRIPTION
Current `RankedComparator` implementation reorders lists of elements that have equal priorities - it never returns 0. 

For example, it changes ordering of filters in `ContainerFilteringStage` of jersey-server, which may result in unexpected and hard to debug behaviours.

This PR fixes the issue.