### PR TITLE
Support custom cookiespec registries and cookie stores in ApacheConnector

### DIFF
--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
@@ -40,7 +40,6 @@
 package org.glassfish.jersey.apache.connector;
 
 import java.util.Map;
-
 import org.glassfish.jersey.internal.util.PropertiesClass;
 import org.glassfish.jersey.internal.util.PropertiesHelper;
 
@@ -144,6 +143,12 @@ public final class ApacheClientProperties {
      * @since 2.5
      */
     public static final String REQUEST_CONFIG = "jersey.config.apache.client.requestConfig";
+
+    /**
+     * An implementation of {@link org.apache.http.config.Lookup} that should be used as a
+     * {@link org.apache.http.config.Registry} of {@link org.apache.http.cookie.CookieSpecProvider}s.
+     */
+    public static final String COOKIESPEC_REGISTRY = "jersey.config.apache.client.cookiespecRegistry";
 
     /**
      * Get the value of the specified property.

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
@@ -40,6 +40,7 @@
 package org.glassfish.jersey.apache.connector;
 
 import java.util.Map;
+
 import org.glassfish.jersey.internal.util.PropertiesClass;
 import org.glassfish.jersey.internal.util.PropertiesHelper;
 

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -55,30 +55,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.client.ClientRequest;
-import org.glassfish.jersey.client.ClientResponse;
-import org.glassfish.jersey.client.RequestEntityProcessing;
-import org.glassfish.jersey.client.spi.AsyncConnectorCallback;
-import org.glassfish.jersey.client.spi.Connector;
-import org.glassfish.jersey.internal.util.PropertiesHelper;
-import org.glassfish.jersey.message.internal.HeaderUtils;
-import org.glassfish.jersey.message.internal.OutboundMessageContext;
-import org.glassfish.jersey.message.internal.ReaderWriter;
-import org.glassfish.jersey.message.internal.Statuses;
-
+import jersey.repackaged.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -123,8 +109,17 @@ import org.apache.http.impl.io.ChunkedOutputStream;
 import org.apache.http.io.SessionOutputBuffer;
 import org.apache.http.util.TextUtils;
 import org.apache.http.util.VersionInfo;
-
-import jersey.repackaged.com.google.common.util.concurrent.MoreExecutors;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.ClientRequest;
+import org.glassfish.jersey.client.ClientResponse;
+import org.glassfish.jersey.client.RequestEntityProcessing;
+import org.glassfish.jersey.client.spi.AsyncConnectorCallback;
+import org.glassfish.jersey.client.spi.Connector;
+import org.glassfish.jersey.internal.util.PropertiesHelper;
+import org.glassfish.jersey.message.internal.HeaderUtils;
+import org.glassfish.jersey.message.internal.OutboundMessageContext;
+import org.glassfish.jersey.message.internal.ReaderWriter;
+import org.glassfish.jersey.message.internal.Statuses;
 
 /**
  * A {@link Connector} that utilizes the Apache HTTP Client to send and receive
@@ -236,7 +231,7 @@ class ApacheConnector implements Connector {
             }
         }
 
-        Object cookiespecRegistryObj = config.getProperties().get(HttpClientContext.COOKIESPEC_REGISTRY);
+        Object cookiespecRegistryObj = config.getProperties().get(ApacheClientProperties.COOKIESPEC_REGISTRY);
         if (cookiespecRegistryObj == null) {
             cookiespecRegistry = null;
         } else {

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -105,6 +105,7 @@ import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLContexts;
+import org.apache.http.cookie.CookieSpecProvider;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.entity.ContentLengthStrategy;
@@ -432,6 +433,23 @@ class ApacheConnector implements Connector {
                 authCache.put(getHost(request), basicScheme);
                 context.setAuthCache(authCache);
             }
+
+            Object cookiespecRegistry = clientRequest.getConfiguration().getProperties()
+                .get(HttpClientContext.COOKIESPEC_REGISTRY);
+            if (cookiespecRegistry != null) {
+                if (!(cookiespecRegistry instanceof Registry)) {
+                    LOGGER.log(
+                            Level.WARNING,
+                            LocalizationMessages.IGNORING_VALUE_OF_PROPERTY(
+                                    HttpClientContext.COOKIESPEC_REGISTRY,
+                                    cookiespecRegistry.getClass().getName(),
+                                    Registry.class.getName())
+                    );
+                    cookiespecRegistry = null;
+                }
+            }
+            context.setCookieSpecRegistry((Registry<CookieSpecProvider>) cookiespecRegistry);
+
             response = client.execute(getHost(request), request, context);
             HeaderUtils.checkHeaderChanges(clientHeadersSnapshot, clientRequest.getHeaders(), this.getClass().getName());
 

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -55,16 +55,30 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
+
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import jersey.repackaged.com.google.common.util.concurrent.MoreExecutors;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.ClientRequest;
+import org.glassfish.jersey.client.ClientResponse;
+import org.glassfish.jersey.client.RequestEntityProcessing;
+import org.glassfish.jersey.client.spi.AsyncConnectorCallback;
+import org.glassfish.jersey.client.spi.Connector;
+import org.glassfish.jersey.internal.util.PropertiesHelper;
+import org.glassfish.jersey.message.internal.HeaderUtils;
+import org.glassfish.jersey.message.internal.OutboundMessageContext;
+import org.glassfish.jersey.message.internal.ReaderWriter;
+import org.glassfish.jersey.message.internal.Statuses;
+
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -109,17 +123,8 @@ import org.apache.http.impl.io.ChunkedOutputStream;
 import org.apache.http.io.SessionOutputBuffer;
 import org.apache.http.util.TextUtils;
 import org.apache.http.util.VersionInfo;
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.client.ClientRequest;
-import org.glassfish.jersey.client.ClientResponse;
-import org.glassfish.jersey.client.RequestEntityProcessing;
-import org.glassfish.jersey.client.spi.AsyncConnectorCallback;
-import org.glassfish.jersey.client.spi.Connector;
-import org.glassfish.jersey.internal.util.PropertiesHelper;
-import org.glassfish.jersey.message.internal.HeaderUtils;
-import org.glassfish.jersey.message.internal.OutboundMessageContext;
-import org.glassfish.jersey.message.internal.ReaderWriter;
-import org.glassfish.jersey.message.internal.Statuses;
+
+import jersey.repackaged.com.google.common.util.concurrent.MoreExecutors;
 
 /**
  * A {@link Connector} that utilizes the Apache HTTP Client to send and receive

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -136,6 +136,7 @@ import jersey.repackaged.com.google.common.util.concurrent.MoreExecutors;
  * <li>{@link ApacheClientProperties#REQUEST_CONFIG}</li>
  * <li>{@link ApacheClientProperties#CREDENTIALS_PROVIDER}</li>
  * <li>{@link ApacheClientProperties#DISABLE_COOKIES}</li>
+ * <li>{@link ApacheClientProperties#COOKIESPEC_REGISTRY}</li>
  * <li>{@link ClientProperties#PROXY_URI}</li>
  * <li>{@link ClientProperties#PROXY_USERNAME}</li>
  * <li>{@link ClientProperties#PROXY_PASSWORD}</li>

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -95,6 +95,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.config.ConnectionConfig;
+import org.apache.http.config.Lookup;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
@@ -199,6 +200,7 @@ class ApacheConnector implements Connector {
     private final CookieStore cookieStore;
     private final boolean preemptiveBasicAuth;
     private final RequestConfig requestConfig;
+    private final Lookup<CookieSpecProvider> cookiespecRegistry;
 
     /**
      * Create the new Apache HTTP Client connector.
@@ -231,6 +233,24 @@ class ApacheConnector implements Connector {
                                 RequestConfig.class.getName())
                 );
                 reqConfig = null;
+            }
+        }
+
+        Object cookiespecRegistryObj = config.getProperties().get(HttpClientContext.COOKIESPEC_REGISTRY);
+        if (cookiespecRegistryObj == null) {
+            cookiespecRegistry = null;
+        } else {
+            if (cookiespecRegistryObj instanceof Lookup) {
+                cookiespecRegistry = (Lookup<CookieSpecProvider>) cookiespecRegistryObj;
+            } else {
+                LOGGER.log(
+                        Level.WARNING,
+                        LocalizationMessages.IGNORING_VALUE_OF_PROPERTY(
+                                HttpClientContext.COOKIESPEC_REGISTRY,
+                                cookiespecRegistryObj.getClass().getName(),
+                                Registry.class.getName())
+                );
+                cookiespecRegistry = null;
             }
         }
 
@@ -434,21 +454,9 @@ class ApacheConnector implements Connector {
                 context.setAuthCache(authCache);
             }
 
-            Object cookiespecRegistry = clientRequest.getConfiguration().getProperties()
-                .get(HttpClientContext.COOKIESPEC_REGISTRY);
             if (cookiespecRegistry != null) {
-                if (!(cookiespecRegistry instanceof Registry)) {
-                    LOGGER.log(
-                            Level.WARNING,
-                            LocalizationMessages.IGNORING_VALUE_OF_PROPERTY(
-                                    HttpClientContext.COOKIESPEC_REGISTRY,
-                                    cookiespecRegistry.getClass().getName(),
-                                    Registry.class.getName())
-                    );
-                    cookiespecRegistry = null;
-                }
+                context.setCookieSpecRegistry(cookiespecRegistry);
             }
-            context.setCookieSpecRegistry((Registry<CookieSpecProvider>) cookiespecRegistry);
 
             response = client.execute(getHost(request), request, context);
             HeaderUtils.checkHeaderChanges(clientHeadersSnapshot, clientRequest.getHeaders(), this.getClass().getName());


### PR DESCRIPTION
Expose the underlying Apache HttpClient support for custom cookiespec registries and cookie stores to users of the Jersey API. Modeled after similar existing exposures (e.g., of HttpClient's REQUEST_CONFIG property).