### PR TITLE
JERSEY-2940 Allow runtime compatibility with jetty 9.3

### DIFF
--- a/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
+++ b/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
@@ -163,7 +163,7 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     public void handle(final String target, final Request request, final HttpServletRequest httpServletRequest,
                        final HttpServletResponse httpServletResponse) throws IOException, ServletException {
 
-        final Response response = Response.getResponse(httpServletResponse);
+        final Response response = request.getResponse();
         final ResponseWriter responseWriter = new ResponseWriter(request, response, configSetStatusOverSendError);
         final URI baseUri = getBaseUri(request);
         final URI requestUri = getRequestUri(request, baseUri);


### PR DESCRIPTION
This change still compiles against jetty 9.2, but allows runtime
compatibility with jetty 9.3 in the case we're hitting
