### PR TITLE
Support for custom cookiespec registries and cookie stores to Apache …

### DIFF
--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
@@ -40,7 +40,6 @@
 package org.glassfish.jersey.apache.connector;
 
 import java.util.Map;
-
 import org.glassfish.jersey.internal.util.PropertiesClass;
 import org.glassfish.jersey.internal.util.PropertiesHelper;
 
@@ -144,6 +143,17 @@ public final class ApacheClientProperties {
      * @since 2.5
      */
     public static final String REQUEST_CONFIG = "jersey.config.apache.client.requestConfig";
+
+    /**
+     * An implementation of {@link org.apache.http.config.Lookup} that should be used as a
+     * {@link org.apache.http.config.Registry} of {@link org.apache.http.cookie.CookieSpecProvider}s.
+     */
+    public static final String COOKIE_SPEC_REGISTRY = "jersey.config.apache.client.cookieSpecRegistry";
+
+    /**
+     * An implementation of {@link org.apache.http.client.CookieStore} that should be used as the cookie store
+     */
+    public static final String COOKIE_STORE = "jersey.config.apache.client.cookieStore";
 
     /**
      * Get the value of the specified property.


### PR DESCRIPTION
…connector

Added new ApacheClientProperties:

* ApacheClientProperties.COOKIE_SPEC_REGISTRY
* ApacheClientProperties.COOKIE_STORE

which can be used to supply custom CookieStore and CookieSpecRegistry
objects to HttpClient.