### PR TITLE
Project Reactor Client Reactive Implementation

### DIFF
--- a/ext/rx/rx-client-reactor/pom.xml
+++ b/ext/rx/rx-client-reactor/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    http://glassfish.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.jersey.ext.rx</groupId>
+        <artifactId>project</artifactId>
+        <version>2.25</version>
+    </parent>
+
+    <artifactId>jersey-rx-client-rxjava</artifactId>
+    <name>jersey-ext-rx-client-rxjava</name>
+
+    <description>Jersey Reactive Client - RxJava (Observable) provider.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.rx</groupId>
+            <artifactId>jersey-rx-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>${projectreactor.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/JerseyPublisherInvoker.java
+++ b/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/JerseyPublisherInvoker.java
@@ -1,0 +1,91 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.client.rx.rxjava;
+
+import java.util.concurrent.ExecutorService;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.GenericType;
+
+import org.glassfish.jersey.client.rx.spi.AbstractRxInvoker;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Implementation of Reactive Invoker for {@code Publisher}.
+ *
+ * @author Adam Richeimer
+ */
+@SuppressWarnings({ "unchecked", "rawtypes" })
+final class JerseyPublisherInvoker extends AbstractRxInvoker<Publisher> implements RxPublisherInvoker {
+
+    private Scheduler scheduler;
+
+    public JerseyPublisherInvoker(final Invocation.Builder builder, final ExecutorService executor) {
+        super(builder, executor);
+        if(executor != null){
+            this.scheduler = Schedulers.fromExecutorService(executor);
+        } else {
+            // Reasonable default scheduler
+            this.scheduler = Schedulers.newElastic("jersey-client-async-executor");
+        }
+    }
+
+    @Override
+    public <T> Publisher<T> method(final String name, final Entity<?> entity, final Class<T> responseType) {
+        return method(name, entity, new GenericType<T>(responseType) {});
+    }
+
+    @Override
+    public <T> Publisher<T> method(final String name, final Entity<?> entity, final GenericType<T> responseType) {
+
+        return Mono.fromCallable(() -> {
+            return getBuilder().method(name, entity, responseType);
+        })
+                .publishOn(scheduler)
+                .subscribeOn(scheduler);
+
+    }
+}

--- a/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/RxPublisher.java
+++ b/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/RxPublisher.java
@@ -1,0 +1,156 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.client.rx.rxjava;
+
+import java.util.concurrent.ExecutorService;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+
+import org.glassfish.jersey.client.rx.Rx;
+import org.glassfish.jersey.client.rx.RxClient;
+import org.glassfish.jersey.client.rx.RxWebTarget;
+
+import reactor.core.scheduler.Scheduler;
+
+/**
+ * Main entry point to the Reactive Client API used to bootstrap {@link org.glassfish.jersey.client.rx.RxClient reactive client}
+ * or {@link org.glassfish.jersey.client.rx.RxWebTarget reactive client target} instances based on Reactive Streams's
+ * {@link org.reactivestreams publisher} using the Project Reactor implementation.
+ *
+ * @author Adam Richeimer
+ * @see org.glassfish.jersey.client.rx.Rx
+ * @since 3.0
+ */
+public final class RxPublisher {
+
+    /**
+     * Create a new {@link org.glassfish.jersey.client.rx.RxClient reactive client} instance parameterized with invoker based on
+     * the {@link org.reactivestreams publisher} from Reactive Streams as implemented by Project Reactor.
+     * <p/>
+     * Instance is initialized with a JAX-RS client created using the default client builder implementation class provided by the
+     * JAX-RS implementation provider.
+     *
+     * @return new reactive client extension.
+     * @see Rx#newClient(Class)
+     */
+    public static RxClient<RxPublisherInvoker> newClient() {
+        return Rx.newClient(RxPublisherInvoker.class);
+    }
+
+    /**
+     * Create a new {@link org.glassfish.jersey.client.rx.RxClient reactive client} instance parameterized with invoker based on
+     * the {@link org.reactivestreams publisher} from Reactive Streams as implemented by Project Reactor. Reactive requests, invoked using
+     * {@link org.glassfish.jersey.client.rx.RxInvocationBuilder#rx() rx(...)}, operate on a {@link Scheduler} initialized with
+     * provided {@link java.util.concurrent.ExecutorService executor service}.
+     * <p/>
+     * Instance is initialized with a JAX-RS client created using the default client builder implementation class provided by the
+     * JAX-RS implementation provider.
+     *
+     * @param executorService the executor service to execute reactive requests.
+     * @return new reactive client extension.
+     * @see Rx#newClient(Class)
+     */
+    public static RxClient<RxPublisherInvoker> newClient(final ExecutorService executorService) {
+        return Rx.newClient(RxPublisherInvoker.class, executorService);
+    }
+
+    /**
+     * Create a new {@link org.glassfish.jersey.client.rx.RxClient reactive client} instance initialized with given JAX-RS client
+     * instance and parameterized with invoker based on the {@link org.reactivestreams publisher} from Reactive Streams as implemented by Project Reactor.
+     *
+     * @param client the JAX-RS client used to initialize new reactive client extension.
+     * @return new reactive client extension.
+     * @see Rx#from(javax.ws.rs.client.Client, Class)
+     */
+    public static RxClient<RxPublisherInvoker> from(final Client client) {
+        return Rx.from(client, RxPublisherInvoker.class);
+    }
+
+    /**
+     * Create a new {@link org.glassfish.jersey.client.rx.RxClient reactive client} instance initialized with given JAX-RS client
+     * instance and parameterized with invoker based on the {@link org.reactivestreams publisher} from Reactive Streams as implemented by Project Reactor. Reactive requests,
+     * invoked using {@link org.glassfish.jersey.client.rx.RxInvocationBuilder#rx() rx(...)}, operate on a {@link Scheduler}
+     * initialized with provided {@link java.util.concurrent.ExecutorService executor service}.
+     *
+     * @param client the JAX-RS client used to initialize new reactive client extension.
+     * @param executorService the executor service to execute reactive requests.
+     * @return new reactive client extension.
+     * @see Rx#from(javax.ws.rs.client.Client, Class)
+     */
+    public static RxClient<RxPublisherInvoker> from(final Client client, final ExecutorService executorService) {
+        return Rx.from(client, RxPublisherInvoker.class, executorService);
+    }
+
+    /**
+     * Create a new {@link org.glassfish.jersey.client.rx.RxWebTarget reactive client target} instance initialized with given
+     * JAX-RS client web target instance and parameterized with invoker based on the {@link org.reactivestreams publisher} from Reactive Streams as implemented by Project Reactor.
+     *
+     * @param target the JAX-RS client target used to initialize new reactive client target extension.
+     * @return new reactive client target extension.
+     * @see Rx#from(javax.ws.rs.client.WebTarget, Class)
+     */
+    public static RxWebTarget<RxPublisherInvoker> from(final WebTarget target) {
+        return Rx.from(target, RxPublisherInvoker.class);
+    }
+
+    /**
+     * Create a new {@link org.glassfish.jersey.client.rx.RxWebTarget reactive client target} instance initialized with given
+     * JAX-RS client web target instance and parameterized with invoker based on the {@link org.reactivestreams publisher} from Reactive Streams as implemented by Project Reactor.
+     * Reactive requests, invoked using {@link org.glassfish.jersey.client.rx.RxInvocationBuilder#rx() rx(...)}, operate on a
+     * {@link Scheduler} initialized with provided {@link java.util.concurrent.ExecutorService executor service}.
+     *
+     * @param target the JAX-RS client target used to initialize new reactive client target extension.
+     * @param executorService the executor service to execute reactive requests.
+     * @return new reactive client target extension.
+     * @see Rx#from(javax.ws.rs.client.WebTarget, Class)
+     */
+    public static RxWebTarget<RxPublisherInvoker> from(final WebTarget target, final ExecutorService executorService) {
+        return Rx.from(target, RxPublisherInvoker.class, executorService);
+    }
+
+    /**
+     * Prevent instantiation.
+     */
+    private RxPublisher() {
+        throw new AssertionError("No instances allowed.");
+    }
+}

--- a/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/RxPublisherInvoker.java
+++ b/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/RxPublisherInvoker.java
@@ -1,0 +1,134 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.client.rx.rxjava;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.client.rx.RxInvoker;
+import org.reactivestreams.Publisher;
+
+
+/**
+ * Reactive invoker providing support for {@link org.reactivestreams publisher} from Reactive Streams as implemented by Project Reactor.
+ *
+ * @author Adam Richeimer
+ * @since 2.13
+ */
+@SuppressWarnings("rawtypes")
+public interface RxPublisherInvoker extends RxInvoker<Publisher> {
+
+    @Override
+    public Publisher<Response> get();
+
+    @Override
+    public <T> Publisher<T> get(Class<T> responseType);
+
+    @Override
+    public <T> Publisher<T> get(GenericType<T> responseType);
+
+    @Override
+    public Publisher<Response> put(Entity<?> entity);
+
+    @Override
+    public <T> Publisher<T> put(Entity<?> entity, Class<T> clazz);
+
+    @Override
+    public <T> Publisher<T> put(Entity<?> entity, GenericType<T> type);
+
+    @Override
+    public Publisher<Response> post(Entity<?> entity);
+
+    @Override
+    public <T> Publisher<T> post(Entity<?> entity, Class<T> clazz);
+
+    @Override
+    public <T> Publisher<T> post(Entity<?> entity, GenericType<T> type);
+
+    @Override
+    public Publisher<Response> delete();
+
+    @Override
+    public <T> Publisher<T> delete(Class<T> responseType);
+
+    @Override
+    public <T> Publisher<T> delete(GenericType<T> responseType);
+
+    @Override
+    public Publisher<Response> head();
+
+    @Override
+    public Publisher<Response> options();
+
+    @Override
+    public <T> Publisher<T> options(Class<T> responseType);
+
+    @Override
+    public <T> Publisher<T> options(GenericType<T> responseType);
+
+    @Override
+    public Publisher<Response> trace();
+
+    @Override
+    public <T> Publisher<T> trace(Class<T> responseType);
+
+    @Override
+    public <T> Publisher<T> trace(GenericType<T> responseType);
+
+    @Override
+    public Publisher<Response> method(String name);
+
+    @Override
+    public <T> Publisher<T> method(String name, Class<T> responseType);
+
+    @Override
+    public <T> Publisher<T> method(String name, GenericType<T> responseType);
+
+    @Override
+    public Publisher<Response> method(String name, Entity<?> entity);
+
+    @Override
+    public <T> Publisher<T> method(String name, Entity<?> entity, Class<T> responseType);
+
+    @Override
+    public <T> Publisher<T> method(String name, Entity<?> entity, GenericType<T> responseType);
+}

--- a/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/RxPublisherInvokerProvider.java
+++ b/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/RxPublisherInvokerProvider.java
@@ -1,0 +1,64 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.client.rx.rxjava;
+
+import java.util.concurrent.ExecutorService;
+
+import javax.ws.rs.client.Invocation;
+
+import org.glassfish.jersey.client.rx.spi.RxInvokerProvider;
+
+/**
+ * Invoker provider for invokers based on RxJava's {@code Observable}.
+ *
+ * @author Adam Richeimer
+ * @since 3.0
+ */
+public final class RxPublisherInvokerProvider implements RxInvokerProvider {
+
+    @Override
+    public <T> T getInvoker(final Class<T> invokerType, final Invocation.Builder builder, final ExecutorService executor) {
+        if (RxPublisherInvoker.class.isAssignableFrom(invokerType)) {
+            return invokerType.cast(new JerseyPublisherInvoker(builder, executor));
+        }
+        return null;
+    }
+}

--- a/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/package-info.java
+++ b/ext/rx/rx-client-reactor/src/main/java/org/glassfish/jersey/client/rx/rxjava/package-info.java
@@ -1,0 +1,44 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+/**
+ * Jersey Reactive Client - Reactive Streams (Publisher) provider using the Project Reactor implementation.
+ */
+package org.glassfish.jersey.client.rx.rxjava;

--- a/ext/rx/rx-client-reactor/src/main/resources/META-INF/services/org.glassfish.jersey.client.rx.spi.RxInvokerProvider
+++ b/ext/rx/rx-client-reactor/src/main/resources/META-INF/services/org.glassfish.jersey.client.rx.spi.RxInvokerProvider
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.rx.rxjava.RxPublisherInvokerProvider

--- a/ext/rx/rx-client-reactor/src/test/java/org/glassfish/jersey/client/rx/rxjava/RxPublisherTest.java
+++ b/ext/rx/rx-client-reactor/src/test/java/org/glassfish/jersey/client/rx/rxjava/RxPublisherTest.java
@@ -1,0 +1,245 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2016 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.client.rx.rxjava;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.client.rx.RxClient;
+import org.glassfish.jersey.client.rx.RxWebTarget;
+import org.glassfish.jersey.process.JerseyProcessingUncaughtExceptionHandler;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+
+import jersey.repackaged.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Adam Richeimer
+ */
+public class RxPublisherTest {
+
+    private Client client;
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() throws Exception {
+        client = ClientBuilder.newClient().register(TerminalClientRequestFilter.class);
+        executor = new ScheduledThreadPoolExecutor(1, new ThreadFactoryBuilder()
+                .setNameFormat("jersey-rx-client-test-%d")
+                .setUncaughtExceptionHandler(new JerseyProcessingUncaughtExceptionHandler())
+                .build());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdown();
+
+        client.close();
+        client = null;
+    }
+
+    @Test
+    public void testNewClient() throws Exception {
+        testClient(RxPublisher.newClient().register(TerminalClientRequestFilter.class), false);
+    }
+
+    @Test
+    public void testNewClientExecutor() throws Exception {
+        testClient(RxPublisher.newClient(executor).register(TerminalClientRequestFilter.class), true);
+    }
+
+    @Test
+    public void testFromClient() throws Exception {
+        testClient(RxPublisher.from(client), false);
+    }
+
+    @Test
+    public void testFromClientExecutor() throws Exception {
+        testClient(RxPublisher.from(client, executor), true);
+    }
+
+    @Test
+    public void testFromTarget() throws Exception {
+        testTarget(RxPublisher.from(client.target("http://jersey.java.net")), false);
+    }
+
+    @Test
+    public void testFromTargetExecutor() throws Exception {
+        testTarget(RxPublisher.from(client.target("http://jersey.java.net"), executor), true);
+    }
+
+    @Test
+    public void testNotFoundResponse() throws Exception {
+        final RxPublisherInvoker invoker = RxPublisher.from(client.target("http://jersey.java.net"))
+                .request()
+                .header("Response-Status", 404)
+                .rx();
+
+        testInvoker(invoker, 404, false);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testNotFoundReadEntityViaClass() throws Throwable {
+
+            ((Mono<String>) RxPublisher.from(client.target("http://jersey.java.net"))
+                    .request()
+                    .header("Response-Status", 404)
+                    .rx()
+                    .get(String.class))
+                    .block();
+
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testNotFoundReadEntityViaGenericType() throws Throwable {
+
+            ((Mono<String>) RxPublisher.from(client.target("http://jersey.java.net"))
+                    .request()
+                    .header("Response-Status", 404)
+                    .rx()
+                    .get(new GenericType<String>() {})
+                    ).block();
+    }
+
+
+    @Test
+    public void testReadEntityViaClass() throws Throwable {
+        final String response = ((Mono<String>) RxPublisher.from(client.target("http://jersey.java.net"))
+                .request()
+                .rx()
+                .get(String.class))
+                .block();
+
+        assertThat(response, is("NO-ENTITY"));
+    }
+
+    @Test
+    public void testReadEntityViaGenericType() throws Throwable {
+        final String response = ((Mono<String>) RxPublisher.from(client.target("http://jersey.java.net"))
+                .request()
+                .rx()
+                .get(new GenericType<String>() {}))
+                .block();
+
+        assertThat(response, is("NO-ENTITY"));
+    }
+
+    private void testClient(final RxClient<RxPublisherInvoker> rxClient, final boolean testDedicatedThread) throws Exception {
+        testTarget(rxClient.target("http://jersey.java.net"), testDedicatedThread);
+    }
+
+    private void testTarget(final RxWebTarget<RxPublisherInvoker> rxTarget, final boolean testDedicatedThread)
+            throws Exception {
+        testInvoker(rxTarget.request().rx(), 200, testDedicatedThread);
+    }
+
+    private void testInvoker(final RxPublisherInvoker rx, final int expectedStatus, final boolean testDedicatedThread)
+            throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Response> responseRef = new AtomicReference<>();
+        final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        rx.get().subscribe(new Subscriber<Response>() {
+            
+            
+            @Override
+            public void onComplete() {
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(final Throwable e) {
+                errorRef.set(e);
+                latch.countDown();
+            }
+
+            @Override
+            public void onNext(final Response response) {
+                responseRef.set(response);
+            }
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+
+                subscription.request(1);
+                
+            }
+        });
+
+        latch.await();
+
+        if (errorRef.get() == null) {
+            testResponse(responseRef.get(), expectedStatus, testDedicatedThread);
+        } else {
+            throw (Exception) errorRef.get();
+        }
+    }
+
+    private static void testResponse(final Response response, final int expectedStatus, final boolean testDedicatedThread) {
+        assertThat(response.getStatus(), is(expectedStatus));
+        assertThat(response.readEntity(String.class), is("NO-ENTITY"));
+
+        // Executor.
+        assertThat(response.getHeaderString("Test-Thread"), testDedicatedThread
+                ? containsString("jersey-rx-client-test") : containsString("jersey-client-async-executor"));
+
+        // Properties.
+        assertThat(response.getHeaderString("Test-Uri"), is("http://jersey.java.net"));
+        assertThat(response.getHeaderString("Test-Method"), is("GET"));
+    }
+}

--- a/ext/rx/rx-client-reactor/src/test/java/org/glassfish/jersey/client/rx/rxjava/TerminalClientRequestFilter.java
+++ b/ext/rx/rx-client-reactor/src/test/java/org/glassfish/jersey/client/rx/rxjava/TerminalClientRequestFilter.java
@@ -1,0 +1,86 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.client.rx.rxjava;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Michal Gajdos
+ */
+class TerminalClientRequestFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(final ClientRequestContext requestContext) throws IOException {
+        // Obtain entity - from request or create new.
+        final ByteArrayInputStream entity = new ByteArrayInputStream(
+                requestContext.hasEntity() ? requestContext.getEntity().toString().getBytes() : "NO-ENTITY".getBytes()
+        );
+
+        final int responseStatus = requestContext.getHeaders().getFirst("Response-Status") != null
+                ? (int) requestContext.getHeaders().getFirst("Response-Status") : 200;
+        Response.ResponseBuilder response = Response.status(responseStatus)
+                .entity(entity)
+                .type("text/plain")
+                // Test properties.
+                .header("Test-Thread", Thread.currentThread().getName())
+                .header("Test-Uri", requestContext.getUri().toString())
+                .header("Test-Method", requestContext.getMethod());
+
+        // Request headers -> Response headers (<header> -> Test-Header-<header>)
+        for (final MultivaluedMap.Entry<String, List<String>> entry : requestContext.getStringHeaders().entrySet()) {
+            response = response.header("Test-Header-" + entry.getKey(), entry.getValue());
+        }
+
+        // Request properties -> Response headers (<header> -> Test-Property-<header>)
+        for (final String property : requestContext.getPropertyNames()) {
+            response = response.header("Test-Property-" + property, requestContext.getProperty(property));
+        }
+
+        requestContext.abortWith(response.build());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1900,6 +1900,7 @@
         <pax.exam.version>4.9.1</pax.exam.version>
         <pax.web.version>0.7.4</pax.web.version><!-- TODO: UPGRADE! -->
         <paxexam.mvn.plugin.version>1.2.4</paxexam.mvn.plugin.version>
+        <projectreactor.version>3.0.3.RELEASE</projectreactor.version>
         <rxjava.version>1.0.12</rxjava.version>
         <rome.version>1.0</rome.version>
         <rxjava.version>1.2.3</rxjava.version>


### PR DESCRIPTION
Jersey's reactive client has implementations for Guava and RxJava. This is an implementation using [Project Reactor](https://projectreactor.io). The interface it exposes is a [Reactive Streams ](http://www.reactive-streams.org/) Publisher. This should make it easy to migrate to Java 9 streams in the future.