### PR TITLE
Fix for Jersey-3201

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java
@@ -215,6 +215,36 @@ public final class Providers {
     }
 
     /**
+     * Get the iterable of all default {@link RankedProvider providers} registered for the given service provider
+     * contract in the underlying {@link ServiceLocator HK2 service locator} container.
+     *
+     * @param <T>      service provider contract Java type.
+     * @param locator  underlying HK2 service locator.
+     * @param contract service provider contract.
+     * @return iterable of all default ranked service providers for the contract. Return value is never null.
+     */
+    public static <T> Iterable<RankedProvider<T>> getRankedProviders(final ServiceLocator locator, final Class<T> contract) {
+        final List<ServiceHandle<T>> providers = getServiceHandles(locator, contract);
+        return getRankedProviders(providers);
+    }
+
+    /**
+     * Get the iterable of all custom {@link RankedProvider providers} registered for the given service provider
+     * contract in the underlying {@link ServiceLocator HK2 service locator} container.
+     *
+     * @param <T>      service provider contract Java type.
+     * @param locator  underlying HK2 service locator.
+     * @param contract service provider contract.
+     * @return iterable of all custom ranked service providers for the contract. Return value is never null.
+     */
+    public static <T> Iterable<RankedProvider<T>> getCustomRankedProviders(final ServiceLocator locator,
+                                                                           final Class<T> contract) {
+
+        final List<ServiceHandle<T>> providers = getServiceHandles(locator, contract, CustomAnnotationLiteral.INSTANCE);
+        return getRankedProviders(providers);
+    }
+
+    /**
      * Get the iterable of all {@link RankedProvider providers} (custom and default) registered for the given service provider
      * contract in the underlying {@link ServiceLocator HK2 service locator} container.
      *
@@ -226,7 +256,10 @@ public final class Providers {
     public static <T> Iterable<RankedProvider<T>> getAllRankedProviders(final ServiceLocator locator, final Class<T> contract) {
         final List<ServiceHandle<T>> providers = getServiceHandles(locator, contract, CustomAnnotationLiteral.INSTANCE);
         providers.addAll(getServiceHandles(locator, contract));
+        return getRankedProviders(providers);
+    }
 
+    private static <T> Iterable<RankedProvider<T>> getRankedProviders(final List<ServiceHandle<T>> providers) {
         final LinkedHashMap<ActiveDescriptor<T>, RankedProvider<T>> providerMap =
                 new LinkedHashMap<ActiveDescriptor<T>, RankedProvider<T>>();
 

--- a/core-common/src/main/java/org/glassfish/jersey/message/AbstractEntityProviderModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/AbstractEntityProviderModel.java
@@ -56,6 +56,7 @@ public abstract class AbstractEntityProviderModel<T> {
     private final T provider;
     private final List<MediaType> declaredTypes;
     private final boolean custom;
+    private final int priority;
     private final Class<?> providedType;
 
     /**
@@ -67,15 +68,18 @@ public abstract class AbstractEntityProviderModel<T> {
      * @param declaredTypes declared supported media types.
      * @param custom        custom flag; {@code true} is the provider is custom, {@code false} if the provider is one of the
      *                      default Jersey providers.
+     * @param priority      provider priority.
      * @param providerType  parameterized entity provider type (used to retrieve the provided Java type).
      */
     AbstractEntityProviderModel(final T provider,
                                 final List<MediaType> declaredTypes,
                                 final boolean custom,
+                                final int priority,
                                 final Class<T> providerType) {
         this.provider = provider;
         this.declaredTypes = declaredTypes;
         this.custom = custom;
+        this.priority = priority;
         this.providedType = getProviderClassParam(provider, providerType);
     }
 
@@ -105,6 +109,15 @@ public abstract class AbstractEntityProviderModel<T> {
      */
     public boolean isCustom() {
         return custom;
+    }
+
+    /**
+     * Get the provider priority.
+     *
+     * @return the provider priority.
+     */
+    public int priority() {
+        return priority;
     }
 
     /**

--- a/core-common/src/main/java/org/glassfish/jersey/message/MessageProperties.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/MessageProperties.java
@@ -128,6 +128,40 @@ public final class MessageProperties {
     public static final String LEGACY_WORKERS_ORDERING = "jersey.config.workers.legacyOrdering";
 
     /**
+     * If set to {@code true}, {@link javax.ws.rs.ext.MessageBodyReader MessageBodyReaders} and
+     * {@link javax.ws.rs.ext.MessageBodyWriter MessageBodyWriters} will be ordered by rules from JAX-RS 2.x, except that
+     * priority will be used instead of origin (custom/provided); providers are sorted firstly by declaration distance (see
+     * {@link org.glassfish.jersey.message.internal.MessageBodyFactory.DeclarationDistanceComparator}), then by
+     * {@link javax.ws.rs.core.MediaType MediaType} and afterwards by {@link javax.annotation.Priority Priority} (with custom
+     * providers being given additional priority).
+     * <p />
+     * The additional priority given to custom providers is specified by {@link #CUSTOM_WORKERS_ADDITIONAL_PRIORITY}.
+     * <p />
+     * If set to {@code true}, the value of {@link #LEGACY_WORKERS_ORDERING} will be ignored.
+     * <p />
+     * The default value is {@code false}.
+     * <p />
+     * The name of the configuration property is <code>{@value}</code>.
+     */
+    public static final String PRIORITY_WORKERS_ORDERING = "jersey.config.workers.priorityOrdering";
+
+    /**
+     * Value of the property indicates the additional priority given to custom providers when
+     * {@link #PRIORITY_WORKERS_ORDERING} is set to {@code true}.
+     * <p />
+     * The default value is <code>{@value #CUSTOM_WORKERS_DEFAULT_ADDITIONAL_PRIORITY}</code>.
+     * <p />
+     * The name of the configuration property is <code>{@value}</code>.
+     */
+    public static final String CUSTOM_WORKERS_ADDITIONAL_PRIORITY = "jersey.config.workers.customAdditionalPriority";
+
+    /**
+     * The default additional priority ({@value}) given to custom providers when
+     * {@link #PRIORITY_WORKERS_ORDERING} is set to {@code true}.
+     */
+    public static final int CUSTOM_WORKERS_DEFAULT_ADDITIONAL_PRIORITY = 500;
+
+    /**
      * Prevents instantiation.
      */
     private MessageProperties() {

--- a/core-common/src/main/java/org/glassfish/jersey/message/ReaderModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/ReaderModel.java
@@ -64,9 +64,10 @@ public final class ReaderModel extends AbstractEntityProviderModel<MessageBodyRe
      * @param provider modelled message body reader instance.
      * @param types    supported media types as declared in {@code @Consumes} annotation attached to the provider class.
      * @param custom   custom flag.
+     * @param priority provider priority.
      */
-    public ReaderModel(MessageBodyReader provider, List<MediaType> types, Boolean custom) {
-        super(provider, types, custom, MessageBodyReader.class);
+    public ReaderModel(MessageBodyReader provider, List<MediaType> types, Boolean custom, Integer priority) {
+        super(provider, types, custom, priority, MessageBodyReader.class);
     }
 
     /**

--- a/core-common/src/main/java/org/glassfish/jersey/message/WriterModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/WriterModel.java
@@ -63,9 +63,10 @@ public final class WriterModel extends AbstractEntityProviderModel<MessageBodyWr
      * @param provider modelled message body writer instance.
      * @param types    supported media types as declared in {@code @Consumes} annotation attached to the provider class.
      * @param custom   custom flag.
+     * @param priority provider priority.
      */
-    public WriterModel(MessageBodyWriter provider, List<MediaType> types, Boolean custom) {
-        super(provider, types, custom, MessageBodyWriter.class);
+    public WriterModel(MessageBodyWriter provider, List<MediaType> types, Boolean custom, Integer priority) {
+        super(provider, types, custom, priority, MessageBodyWriter.class);
     }
 
     /**

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/ProvidersPriorityOrderingTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/ProvidersPriorityOrderingTest.java
@@ -1,0 +1,226 @@
+/*
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+*
+* Copyright (c) 2012-2016 Oracle and/or its affiliates. All rights reserved.
+*
+* The contents of this file are subject to the terms of either the GNU
+* General Public License Version 2 only ("GPL") or the Common Development
+* and Distribution License("CDDL") (collectively, the "License").  You
+* may not use this file except in compliance with the License.  You can
+* obtain a copy of the License at
+* http://glassfish.java.net/public/CDDL+GPL_1_1.html
+* or packager/legal/LICENSE.txt.  See the License for the specific
+* language governing permissions and limitations under the License.
+*
+* When distributing the software, include this License Header Notice in each
+* file and include the License file at packager/legal/LICENSE.txt.
+*
+* GPL Classpath Exception:
+* Oracle designates this particular file as subject to the "Classpath"
+* exception as provided by Oracle in the GPL Version 2 section of the License
+* file that accompanied this code.
+*
+* Modifications:
+* If applicable, add the following below the License Header, with the fields
+* enclosed by brackets [] replaced by your own identifying information:
+* "Portions Copyright [year] [name of copyright owner]"
+*
+* Contributor(s):
+* If you wish your version of this file to be governed by only the CDDL or
+* only the GPL Version 2, indicate your decision by adding "[Contributor]
+* elects to include this software in this distribution under the [CDDL or GPL
+* Version 2] license."  If you don't indicate a single choice of license, a
+* recipient has the option to distribute your version of this file under
+* either the CDDL, the GPL Version 2 or to extend the choice of license to
+* its licensees as provided above.  However, if you add GPL Version 2 code
+* and therefore, elected the GPL Version 2 license, then the option applies
+* only if the new code is made subject to such option by the copyright
+* holder.
+*/
+
+package org.glassfish.jersey.tests.e2e.common;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.annotation.Priority;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.glassfish.jersey.message.MessageProperties;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Pavel Bucek (pavel.bucek at oracle.com)
+ * @author David Kleszyk (dkleszyk at gmail.com)
+ */
+public class ProvidersPriorityOrderingTest extends JerseyTest {
+
+    private static final String APPLICATION_TEST = "application/test";
+
+    private static final MediaType APPLICATION_TEST_TYPE = MediaType.valueOf(APPLICATION_TEST);
+
+    @Priority(1500)
+    @Produces(APPLICATION_TEST)
+    public static class MyMBW7 implements MessageBodyWriter<Object> {
+
+        private final List<Class<?>> callList;
+
+        public MyMBW7(List<Class<?>> callList) {
+            this.callList = callList;
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            callList.add(this.getClass());
+            return true;
+        }
+
+        @Override
+        public long getSize(Object myType, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return -1;
+        }
+
+        @Override
+        public void writeTo(Object myType,
+                            Class<?> type,
+                            Type genericType,
+                            Annotation[] annotations,
+                            MediaType mediaType,
+                            MultivaluedMap<String, Object> httpHeaders,
+                            OutputStream entityStream) throws IOException, WebApplicationException {
+        }
+    }
+
+    // @Priority(1000) - explicitly specified by ResourceConfig.register
+    @Produces(APPLICATION_TEST)
+    public static class MyMBW8 implements MessageBodyWriter<Object> {
+
+        private final List<Class<?>> callList;
+
+        public MyMBW8(List<Class<?>> callList) {
+            this.callList = callList;
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            callList.add(this.getClass());
+            return false;
+        }
+
+        @Override
+        public long getSize(Object myType, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return -1;
+        }
+
+        @Override
+        public void writeTo(Object myType,
+                            Class<?> type,
+                            Type genericType,
+                            Annotation[] annotations,
+                            MediaType mediaType,
+                            MultivaluedMap<String, Object> httpHeaders,
+                            OutputStream entityStream) throws IOException, WebApplicationException {
+        }
+    }
+
+    @Priority(500)
+    @Produces(APPLICATION_TEST)
+    public static class MyMBW9 implements MessageBodyWriter<Object> {
+
+        private final List<Class<?>> callList;
+
+        public MyMBW9(List<Class<?>> callList) {
+            this.callList = callList;
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            callList.add(this.getClass());
+            return false;
+        }
+
+        @Override
+        public long getSize(Object myType, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return -1;
+        }
+
+        @Override
+        public void writeTo(Object myType,
+                            Class<?> type,
+                            Type genericType,
+                            Annotation[] annotations,
+                            MediaType mediaType,
+                            MultivaluedMap<String, Object> httpHeaders,
+                            OutputStream entityStream) throws IOException, WebApplicationException {
+        }
+    }
+
+    @Path("/")
+    public static class MyResource {
+
+        @GET
+        @Produces(APPLICATION_TEST)
+        public Object getResponse() {
+            return new Object();
+        }
+    }
+
+    private List<Class<?>> callList;
+
+    @Override
+    protected Application configure() {
+        callList = new ArrayList<>();
+
+        final ResourceConfig resourceConfig = new ResourceConfig(MyResource.class);
+        resourceConfig.registerInstances(new MyMBW7(callList), new MyMBW9(callList));
+        resourceConfig.register(new MyMBW8(callList), 1000);
+        resourceConfig.property(MessageProperties.PRIORITY_WORKERS_ORDERING, true);
+        return resourceConfig;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void orderingTest() {
+        callList.clear();
+
+        try {
+            Response response = target().request(APPLICATION_TEST_TYPE).get(Response.class);
+
+            assertNotNull(response);
+            assertEquals("Request was not handled correctly, most likely fault in MessageBodyWorker selection.",
+                    200, response.getStatus());
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            fail("Request was not handled correctly, most likely fault in MessageBodyWorker selection.");
+        }
+
+        List<Class<?>> classes = Arrays.asList(
+                MyMBW9.class, // MBW - priority 500
+                MyMBW8.class, // MBW - priority 1000
+                MyMBW7.class  // MBW - priority 1500 (returns true from isWriteable)
+        );
+
+        assertEquals(classes, callList);
+    }
+}


### PR DESCRIPTION
This provides a fix for [JERSEY-3201](https://java.net/jira/browse/JERSEY-3201), which is a feature request to allow for sorting of message body workers by priority.

I made the new behavior dependent on an opt-in configuration flag to minimize the chance for disruption with existing deployments.