### PR TITLE
Expose copy constructor of JerseyUriBuilder

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/uri/internal/JerseyUriBuilder.java
+++ b/core-common/src/main/java/org/glassfish/jersey/uri/internal/JerseyUriBuilder.java
@@ -102,7 +102,7 @@ public class JerseyUriBuilder extends UriBuilder {
         query = new StringBuilder();
     }
 
-    private JerseyUriBuilder(final JerseyUriBuilder that) {
+    protected JerseyUriBuilder(final JerseyUriBuilder that) {
         this.scheme = that.scheme;
         this.ssp = that.ssp;
         this.authority = that.authority;


### PR DESCRIPTION
Allow extensions to extend ``JerseyUriBuilder`` and make use of this efficient copy constructor instead of wastefully re-creating a new one from scratch ( ``new`` then ``uri(..)`` ). Forcing to re-create``JerseyUriBuilder`` extensions using ``uri(..)`` causes a critical performance bottleneck in my scenarios.