### PR TITLE
Update pom.xml

### DIFF
--- a/examples/reload/pom.xml
+++ b/examples/reload/pom.xml
@@ -87,6 +87,7 @@
                     <outputFile>${project.build.directory}/classpath.properties</outputFile>
                     <outputFilterFile>true</outputFilterFile>
                     <includeScope>compile</includeScope>
+                    <fileSeparator>/</fileSeparator>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
maven-dependency-plugin uses single \ as file separator on Windows, but single \ is illegal for properties files. For that build fails on Windows. I set it to forward slash, and it builds on Windows.