### PR TITLE
Add BeanParam support to WebResourceFactory

### DIFF
--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParam.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParam.java
@@ -1,0 +1,30 @@
+package org.glassfish.jersey.client.proxy;
+
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.MatrixParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import java.util.List;
+import java.util.SortedSet;
+
+public class MyBeanParam {
+    @QueryParam("query-param") String queryParam;
+    @PathParam("path-param") String pathParam;
+    @HeaderParam("header-param") String headerParam;
+    @CookieParam("cookie-param") String cookieParam;
+    @MatrixParam("matrix-name-sorted") SortedSet<String> matrixParam;
+    @FormParam("form-param") List<String> formParam;
+
+    @Override
+    public String toString() {
+        return String.format("%s:%s:%s:%s:%s:%s",
+                queryParam,
+                pathParam,
+                headerParam,
+                cookieParam,
+                matrixParam,
+                formParam);
+    }
+}

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
@@ -172,6 +172,11 @@ public class MyResource implements MyResourceIfc {
     }
 
     @Override
+    public String postBeanParam(MyBeanParam beanParam) {
+        return beanParam.toString();
+    }
+
+    @Override
     public MySubResourceIfc getSubResource() {
         return new MySubResource();
     }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.FormParam;
@@ -181,6 +182,11 @@ public interface MyResourceIfc {
     @POST
     @Produces(MediaType.TEXT_PLAIN)
     String postByNameFormSortedSet(@FormParam("form-name-sorted") SortedSet<String> name);
+
+    @Path("request/{path-param}")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    String postBeanParam(@BeanParam MyBeanParam name);
 
     @Path("subresource")
     MySubResourceIfc getSubResource();

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -40,6 +40,7 @@
 package org.glassfish.jersey.client.proxy;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -322,6 +323,20 @@ public class WebResourceFactoryTest extends JerseyTest {
 
         final String result = resource.postByNameFormSortedSet(set);
         assertEquals("3:[a, bb, ccc]", result);
+    }
+
+    @Test
+    public void testPostBeanParam() {
+        MyBeanParam beanParam = new MyBeanParam();
+        beanParam.queryParam = "query";
+        beanParam.pathParam = "path";
+        beanParam.headerParam = "header";
+        beanParam.cookieParam = "cookie";
+        beanParam.matrixParam = new TreeSet(Arrays.asList("a", "bb", "ccc"));
+        beanParam.formParam = Arrays.asList("dddd", "eeeee", "ffffff");
+
+        String result = resource.postBeanParam(beanParam);
+        assertEquals(beanParam.toString(), result);
     }
 
     @Test


### PR DESCRIPTION
This allows you to use BeanParam to consolidate argument lists for requests with many QueryParams (or other types of parameters).
