### PR TITLE
Logging : Max entity size limit check

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
@@ -203,9 +203,9 @@ public class LoggingFeature implements Feature {
      * Creates the feature with custom logger and maximum number of bytes of entity to log.
      *
      * @param logger        the logger to log requests and responses.
-     * @param maxEntitySize maximum number of entity bytes to be logged (and buffered) - if the entity is larger,
-     *                      logging filter will print (and buffer in memory) only the specified number of bytes
-     *                      and print "...more..." string at the end. Negative values are interpreted as zero.
+     * @param maxEntitySize maximum number of entity bytes to be logged (and buffered) - if the entity is larger, logging filter will print
+     *                      (and buffer in memory) only the specified number of bytes and print "...more..." string at the end. Negative
+     *                      values are interpreted as zero.
      */
     public LoggingFeature(Logger logger, Integer maxEntitySize) {
         this(logger, null, DEFAULT_VERBOSITY, maxEntitySize);
@@ -217,15 +217,15 @@ public class LoggingFeature implements Feature {
      * @param logger        the logger to log requests and responses.
      * @param level         level on which the messages will be logged.
      * @param verbosity     verbosity of logged messages. See {@link Verbosity}.
-     * @param maxEntitySize maximum number of entity bytes to be logged (and buffered) - if the entity is larger,
-     *                      logging filter will print (and buffer in memory) only the specified number of bytes
-     *                      and print "...more..." string at the end. Negative values are interpreted as zero.
+     * @param maxEntitySize maximum number of entity bytes to be logged (and buffered) - if the entity is larger, logging filter will print
+     *                      (and buffer in memory) only the specified number of bytes and print "...more..." string at the end. Negative
+     *                      values are interpreted as zero.
      */
     public LoggingFeature(Logger logger, Level level, Verbosity verbosity, Integer maxEntitySize) {
         this.filterLogger = logger;
         this.level = level;
         this.verbosity = verbosity;
-        this.maxEntitySize = maxEntitySize;
+        this.maxEntitySize = Math.min(Integer.MAX_VALUE - 1, maxEntitySize);
     }
 
     @Override


### PR DESCRIPTION
If a LoggingFeature is registered and provided value for maxEntitySize is set to Integer.MAX_VALUE. Then at runtime, jersey logging throws `NegativeArrayException` which is because of this [line](https://github.com/jersey/jersey/blob/master/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java#L210)

Since, jersey logging treats negative values as 0 and it doesn't log more than `DEFAULT_MAX_ENTITY_SIZE`. So, a check for max value would be great. I read that logging shouldn't cause problem to main call flow. So, here is a suggestion for suppressing the provided `maxEntitySize`. 




