### PR TITLE
Fixes error where Netty was not binding properly to a host.

### DIFF
--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/NettyHttpContainerProvider.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/NettyHttpContainerProvider.java
@@ -107,8 +107,9 @@ public class NettyHttpContainerProvider implements ContainerProvider {
              .childHandler(new JerseyServerInitializer(baseUri, sslContext, container));
 
             int port = getPort(baseUri);
+            String host = getHost(baseUri);
 
-            Channel ch = b.bind(port).sync().channel();
+            Channel ch = b.bind(host, port).sync().channel();
 
             ch.closeFuture().addListener(new GenericFutureListener<Future<? super Void>>() {
                 @Override
@@ -176,8 +177,9 @@ public class NettyHttpContainerProvider implements ContainerProvider {
              .childHandler(new JerseyServerInitializer(baseUri, sslContext, container, true));
 
             int port = getPort(baseUri);
+            String host = getHost(baseUri);
 
-            Channel ch = b.bind(port).sync().channel();
+            Channel ch = b.bind(host, port).sync().channel();
 
             ch.closeFuture().addListener(new GenericFutureListener<Future<? super Void>>() {
                 @Override
@@ -208,5 +210,13 @@ public class NettyHttpContainerProvider implements ContainerProvider {
         }
 
         return uri.getPort();
+    }
+
+    private static String getHost(URI uri) {
+        String host = uri.getHost();
+        if (host == null) {
+            throw new IllegalArgumentException("URI must contain a host.");
+        }
+        return host;
     }
 }


### PR DESCRIPTION
The NettyHttpContainerProvider currently ignores the "host" part of the baseUri. This is ok when you want Netty to bind to the main network interface on a server, but it's a problem when there are multiple interfaces, or you want to do loopback testing. For example, you might want to have one instance of Netty bind to 127.0.0.1 and a second one bind to 127.0.0.2 so you can test communications between the two.