### PR TITLE
Supporting hashCode and equals calls on jersey client proxy objects.

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -163,6 +163,16 @@ public final class WebResourceFactory implements InvocationHandler {
             return toString();
         }
 
+        if (args == null && method.getName().equals("hashCode")) {
+            //unique instance in the JVM, and no need to override
+            return hashCode();
+        }
+
+        if (args != null && args.length == 1 && method.getName().equals("equals")) {
+            //unique instance in the JVM, and no need to override
+            return equals(args[0]);
+        }
+
         // get the interface describing the resource
         final Class<?> proxyIfc = proxy.getClass().getInterfaces()[0];
 

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -61,6 +61,8 @@ import org.glassfish.jersey.test.TestProperties;
 import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -69,6 +71,7 @@ import static org.junit.Assert.assertTrue;
 public class WebResourceFactoryTest extends JerseyTest {
 
     private MyResourceIfc resource;
+    private MyResourceIfc resource2;
     private MyResourceIfc resourceWithXML;
 
     @Override
@@ -86,6 +89,7 @@ public class WebResourceFactoryTest extends JerseyTest {
     public void setUp() throws Exception {
         super.setUp();
         resource = WebResourceFactory.newResource(MyResourceIfc.class, target());
+        resource2 = WebResourceFactory.newResource(MyResourceIfc.class, target());
 
         final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>(1);
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML);
@@ -341,5 +345,17 @@ public class WebResourceFactoryTest extends JerseyTest {
         final String expected = target().path("myresource").toString();
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testHashCode() throws Exception {
+        int h1 = resource.hashCode();
+        int h2 = resource2.hashCode();
+        assertNotEquals("The hash codes should not match", h1, h2);
+    }
+
+    @Test
+    public void testEquals() {
+        assertFalse("The two resource instances should not be considered equals as they are unique", resource.equals(resource2));
     }
 }


### PR DESCRIPTION
Spring Boot 1.4+ and some other things have issues because hashCode and equals will throw unsupported exceptions. I have signed the OCA a long time back; you can see my name in the list. Please review and merge.

This will also need to be back ported to 2.x. Do I need to do that and submit a PR? If so, what is the normal flow for that in the Jersey project.