### PR TITLE
Fix netty connector request.async readtimeout issue

### DIFF
--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyConnector.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyConnector.java
@@ -82,6 +82,7 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientRequest;
 import org.glassfish.jersey.client.ClientResponse;
@@ -202,6 +203,11 @@ class NettyConnector implements Connector {
                      p.addLast(new ChunkedWriteHandler());
                      p.addLast(new HttpContentDecompressor());
                      p.addLast(new JerseyClientHandler(NettyConnector.this, jerseyRequest, jerseyCallback, settableFuture));
+                     Integer readTimeout = ClientProperties.getValue(jerseyRequest.getConfiguration().getProperties(),
+                                                        ClientProperties.READ_TIMEOUT, 0);
+                     if (readTimeout > 0) {
+                          p.addFirst(new ReadTimeoutHandler(readTimeout, TimeUnit.MILLISECONDS));
+                     }
                  }
              });
 

--- a/connectors/netty-connector/src/test/java/org/glassfish/jersey/netty/connector/TimeoutTest.java
+++ b/connectors/netty-connector/src/test/java/org/glassfish/jersey/netty/connector/TimeoutTest.java
@@ -40,6 +40,10 @@
 
 package org.glassfish.jersey.netty.connector;
 
+import io.netty.handler.timeout.ReadTimeoutException;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 import javax.ws.rs.GET;
@@ -53,6 +57,7 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -107,6 +112,18 @@ public class TimeoutTest extends JerseyTest {
         } catch (ProcessingException e) {
             assertThat("Unexpected processing exception cause",
                        e.getCause(), instanceOf(TimeoutException.class));
+        }
+    }
+
+    @Test
+    public void testAsyncSlow() {
+        try {
+            Future<Response> future = target("test/timeout").request().async().get();
+            future.get();
+            fail("Timeout expected.");
+        } catch (ProcessingException | InterruptedException | ExecutionException e) {
+            assertThat("Unexpected processing exception cause",
+                e.getCause().getCause(), instanceOf(ReadTimeoutException.class));
         }
     }
 }


### PR DESCRIPTION
The readtimeout is not working when it works with jersey "request().async()" on netty connector.

```
Future<Response> future = target("test/timeout").request().async().get();
future.get();
```