### PR TITLE
Add batching to ChunkedOutput

### DIFF
--- a/core-server/src/main/resources/org/glassfish/jersey/server/internal/localization.properties
+++ b/core-server/src/main/resources/org/glassfish/jersey/server/internal/localization.properties
@@ -135,6 +135,7 @@ get.returns.void=A HTTP GET method, {0}, returns a void type. It can be intentio
 event.sink.returns.type=A HTTP GET method {0} that is being injected with SseEventSink should return void. The output will propagate automatically.
 multiple.event.sink.injection=A HTTP GET method {0} defines to SseEventSink parameters to be injected. Only one of the injected event sinks will be connected to the output.
 chunked.output.closed=This chunked output has been closed.
+chunked.output.batch.closed=This chunked output batch has been closed.
 illegal.client.config.class.property.value="{0}" property value ({1}) does not represent a valid client configuration class. Falling back to "{2}".
 init.msg=Initiating Jersey application, version {0}...
 injected.webtarget.uri.invalid="@Uri" annotation value is not a valid URI template: "{0}"

--- a/core-server/src/test/java/org/glassfish/jersey/server/ChunkedOutputTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/ChunkedOutputTest.java
@@ -1,0 +1,90 @@
+package org.glassfish.jersey.server;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.glassfish.jersey.server.internal.LocalizationMessages;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ChunkedOutputTest {
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testBatchClose() throws Exception {
+    final ChunkedOutput<Object> subject = new ChunkedOutput<Object>(Object.class);
+
+    final Object o1 = new Object(), o2 = new Object();
+
+    ChunkedOutput.Batch<Object> ref;
+    try (final ChunkedOutput.Batch<Object> batch = subject.batch()) {
+      ref = batch;
+
+      batch.add(o1);
+      batch.add(o2);
+    }
+
+    assertThat(subject.queue, contains(o1, o2));
+    assertTrue(ref.isClosed());
+  }
+
+  @Test
+  public void testBatchDoubleClose() throws Exception {
+    final ChunkedOutput<Object> subject = new ChunkedOutput<Object>(Object.class);
+
+    try (final ChunkedOutput.Batch<Object> batch = subject.batch()) {
+      batch.close();
+
+      expectedException.expect(IOException.class);
+      expectedException.expectMessage(is(LocalizationMessages.CHUNKED_OUTPUT_BATCH_CLOSED()));
+    }
+  }
+
+  @Test
+  public void testBatchAddAfterClose() throws Exception {
+    final ChunkedOutput<Object> subject = new ChunkedOutput<Object>(Object.class);
+
+    ChunkedOutput.Batch<Object> ref;
+    try (final ChunkedOutput.Batch<Object> batch = subject.batch()) {
+      ref = batch;
+    }
+
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage(is(LocalizationMessages.CHUNKED_OUTPUT_BATCH_CLOSED()));
+
+    ref.add(new Object());
+  }
+
+  @Test
+  public void testBatchAddNull() throws Exception {
+    final ChunkedOutput<Object> subject = new ChunkedOutput<Object>(Object.class);
+
+    try (final ChunkedOutput.Batch<Object> batch = subject.batch()) {
+      batch.add(null);
+    }
+
+    assertThat(subject.queue, empty());
+  }
+
+  @Test
+  public void testBatchWriteToClosedChunkedOutput() throws Exception {
+    final ChunkedOutput<Object> subject = new ChunkedOutput<Object>(Object.class);
+
+    try (final ChunkedOutput.Batch<Object> batch = subject.batch()) {
+      subject.close();
+
+      expectedException.expect(IOException.class);
+      expectedException.expectMessage(is(LocalizationMessages.CHUNKED_OUTPUT_CLOSED()));
+
+      batch.add(null);
+    }
+  }
+
+}


### PR DESCRIPTION
Add functionality to `ChunkedOutput` to submit chunks in batches that are then written out together. This is useful when multiple chunks are generated in a short amount of time without having to flush the writer after each one of them. This is sometimes the case, for example, with SSE events sent over an `EventOutput` in high-load scenarios.