### PR TITLE
Changeable invokers for Proxy client

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/JerseyResourceMethodInvoker.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/JerseyResourceMethodInvoker.java
@@ -4,6 +4,9 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.GenericType;
 
+/**
+ * Default method invoker for {@link WebResourceFactory}
+ */
 public class JerseyResourceMethodInvoker implements ResourceMethodInvoker<Invocation.Builder> {
 
     @Override

--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/JerseyResourceMethodInvoker.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/JerseyResourceMethodInvoker.java
@@ -1,0 +1,19 @@
+package org.glassfish.jersey.client.proxy;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.GenericType;
+
+public class JerseyResourceMethodInvoker implements ResourceMethodInvoker<Invocation.Builder> {
+
+    @Override
+    public <T> T method(Invocation.Builder builder, String name, GenericType<T> responseType) {
+        return builder.method(name, responseType);
+    }
+
+    @Override
+    public <T> T method(Invocation.Builder builder, String name, Entity<?> entity, GenericType<T> responseType) {
+        return builder.method(name, entity, responseType);
+    }
+
+}

--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/ResourceMethodInvoker.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/ResourceMethodInvoker.java
@@ -6,8 +6,31 @@ import javax.ws.rs.core.GenericType;
 
 public interface ResourceMethodInvoker<B extends Invocation.Builder> {
 
+    /**
+     * Call corresponding method in specified {@link Invocation.Builder}
+     *
+     * @param <T> generic response entity type.
+     * @param builder invocation builder to trigger
+     * @param name method name
+     * @param responseType representation of a generic Java type the response entity will be converted to.
+     * @return invocation response.
+     *
+     * @see javax.ws.rs.client.SyncInvoker#method(String, GenericType)
+     */
     <T> T method(B builder, String name, GenericType<T> responseType);
 
+    /**
+     * Call corresponding method in specified {@link Invocation.Builder}
+     *
+     * @param <T> generic response entity type.
+     * @param builder invocation builder to trigger
+     * @param name method name
+     * @param entity request entity.
+     * @param responseType representation of a generic Java type the response entity will be converted to.
+     * @return invocation response.
+     *
+     * @see javax.ws.rs.client.SyncInvoker#method(String, Entity, GenericType)
+     */
     <T> T method(B builder, String name, Entity<?> entity, GenericType<T> responseType);
 }
 

--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/ResourceMethodInvoker.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/ResourceMethodInvoker.java
@@ -1,0 +1,14 @@
+package org.glassfish.jersey.client.proxy;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.GenericType;
+
+public interface ResourceMethodInvoker<B extends Invocation.Builder> {
+
+    <T> T method(B builder, String name, GenericType<T> responseType);
+
+    <T> T method(B builder, String name, Entity<?> entity, GenericType<T> responseType);
+}
+
+

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -94,7 +94,8 @@ public class WebResourceFactoryTest extends JerseyTest {
         final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>(1);
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML);
         resourceWithXML = WebResourceFactory
-                .newResource(MyResourceIfc.class, target(), false, headers, Collections.<Cookie>emptyList(), new Form());
+                .newResource(MyResourceIfc.class, target(), false, headers, Collections.<Cookie>emptyList(), new Form(),
+                        new JerseyResourceMethodInvoker());
     }
 
     @Test


### PR DESCRIPTION
Hi,

This PR will add `ResourceMethodInvoker` for proxy client factory.
This will allow to substitute client invocation for example to support RxJava proxy client like [here](https://github.com/alex-shpak/rx-jersey) 
Example:
```
class RxResourceMethodInvoker implements ResourceMethodInvoker<RxInvocationBuilder> {

    @Override
    public <T> T method(RxInvocationBuilder builder, String name, GenericType<T> responseType) {
        return builder.rx().method...;
    }

    @Override
    public <T> T method(RxInvocationBuilder builder, String name, Entity<?> entity, GenericType<T> responseType) {
        return builder.rx().method...;
    }
}
```

OCA is signed and sent.