### PR TITLE
JERSEY-3258: Fixed error handling for async client

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientRuntime.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientRuntime.java
@@ -215,11 +215,10 @@ class ClientRuntime implements JerseyClient.ShutdownHook, ClientExecutor {
         final ClientResponse processedResponse;
         try {
             processedResponse = Stages.process(response, responseProcessingRoot);
+            callback.completed(processedResponse, requestScope);
         } catch (final Throwable throwable) {
             processFailure(throwable, callback);
-            return;
         }
-        callback.completed(processedResponse, requestScope);
     }
 
     private void processFailure(final Throwable failure, final ResponseCallback callback) {


### PR DESCRIPTION
Hi!

PR addressing [JERSEY-3258](https://java.net/jira/browse/JERSEY-3258) bug.
Exceptions thrown while processing response (for example JSON parsing) in async client was not handled properly and was leading client to wait forever.

OCA is signed and sent.