### PR TITLE
Apache connector: Removed unnecessary InputStream.close() call that causes exception on httpclient 4.5.2

### DIFF
--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -478,7 +478,7 @@ class ApacheConnector implements Connector {
             }
 
             try {
-                responseContext.setEntityStream(new HttpClientResponseInputStream(getInputStream(response)));
+                responseContext.setEntityStream(getInputStream(response));
             } catch (final IOException e) {
                 LOGGER.log(Level.SEVERE, null, e);
             }
@@ -617,18 +617,6 @@ class ApacheConnector implements Connector {
         return stringHeaders;
     }
 
-    private static final class HttpClientResponseInputStream extends FilterInputStream {
-
-        HttpClientResponseInputStream(final InputStream inputStream) throws IOException {
-            super(inputStream);
-        }
-
-        @Override
-        public void close() throws IOException {
-            super.close();
-        }
-    }
-
     private static InputStream getInputStream(final CloseableHttpResponse response) throws IOException {
 
         final InputStream inputStream;
@@ -648,7 +636,6 @@ class ApacheConnector implements Connector {
             @Override
             public void close() throws IOException {
                 response.close();
-                super.close();
             }
         };
     }

--- a/connectors/apache-connector/src/test/java/org/glassfish/jersey/apache/connector/StreamingTest.java
+++ b/connectors/apache-connector/src/test/java/org/glassfish/jersey/apache/connector/StreamingTest.java
@@ -49,6 +49,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import javax.inject.Singleton;
 
@@ -85,6 +86,15 @@ public class StreamingTest extends JerseyTest {
         assertEquals("NOK", sendTarget.request().get().readEntity(String.class));
     }
 
+    /**
+     * Tests that closing a request without reading the entity does not throw an exception.
+     */
+    @Test
+    public void clientCloseThrowsNoExceptionTest() throws IOException {
+        Response response = target().path("/streamingEndpoint/get").request().get();
+        response.close();
+    }
+
     @Override
     protected void configureClient(ClientConfig config) {
         config.connectorProvider(new ApacheConnectorProvider());
@@ -117,6 +127,13 @@ public class StreamingTest extends JerseyTest {
         @Produces(MediaType.TEXT_PLAIN)
         public ChunkedOutput<String> get() {
             return output;
+        }
+
+        @GET
+        @Path("get")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getString() {
+            return "OK";
         }
     }
 }


### PR DESCRIPTION
See https://github.com/jersey/jersey/pull/268