### PR TITLE
Optimize UriParser component parsing

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/uri/internal/UriParser.java
+++ b/core-common/src/main/java/org/glassfish/jersey/uri/internal/UriParser.java
@@ -119,8 +119,8 @@ class UriParser {
                 sb.append(c);
 
                 // test IPv6 or regular expressions in the template params
-            } else if ((delimiters != null && delimiters.indexOf(c) >= 0)
-                    && (!isIp || squareBracketsCount == 0) && (curlyBracketsCount == 0)) {
+            } else if ((!isIp || squareBracketsCount == 0) && (curlyBracketsCount == 0)
+                    && (delimiters != null && delimiters.indexOf(c) >= 0)) {
                 return sb.length() == 0 ? null : sb.toString();
             } else {
                 sb.append(c);

--- a/core-common/src/main/java/org/glassfish/jersey/uri/internal/UriParser.java
+++ b/core-common/src/main/java/org/glassfish/jersey/uri/internal/UriParser.java
@@ -103,7 +103,7 @@ class UriParser {
         StringBuilder sb = new StringBuilder();
 
         boolean endOfInput = false;
-        Character c = ci.current();
+        char c = ci.current();
         while (!endOfInput) {
             if (c == '{') {
                 curlyBracketsCount++;


### PR DESCRIPTION
* Avoid unnecessary boxing and unboxing in UriParser
* Reorder conditions to short-circuit before expensive work

JMH benchmarks show ~2x improvement in throughput and ~3x reduction in allocation per operation.

Before:
```
# Run complete. Total time: 00:02:41

Benchmark                                                                              (uriTemplate)   Mode  Cnt        Score       Error   Units
JerseyUriBuilderBenchmark.uri                                            http://localhost:8080/a/b/c  thrpt   16  1007952.090 ± 40053.459   ops/s
JerseyUriBuilderBenchmark.uri:·gc.alloc.rate                             http://localhost:8080/a/b/c  thrpt   16     2452.967 ±    97.481  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.alloc.rate.norm                        http://localhost:8080/a/b/c  thrpt   16     2552.000 ±     0.001    B/op
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Eden_Space                    http://localhost:8080/a/b/c  thrpt   16     2450.247 ±    99.399  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Eden_Space.norm               http://localhost:8080/a/b/c  thrpt   16     2549.158 ±    18.322    B/op
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Survivor_Space                http://localhost:8080/a/b/c  thrpt   16        0.280 ±     0.040  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Survivor_Space.norm           http://localhost:8080/a/b/c  thrpt   16        0.292 ±     0.041    B/op
JerseyUriBuilderBenchmark.uri:·gc.count                                  http://localhost:8080/a/b/c  thrpt   16      799.000              counts
JerseyUriBuilderBenchmark.uri:·gc.time                                   http://localhost:8080/a/b/c  thrpt   16      370.000                  ms
JerseyUriBuilderBenchmark.uri                                   https://localhost:443/{a}/{b}/{c:.+}  thrpt   16   831523.664 ± 14944.928   ops/s
JerseyUriBuilderBenchmark.uri:·gc.alloc.rate                    https://localhost:443/{a}/{b}/{c:.+}  thrpt   16     2359.806 ±    42.419  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.alloc.rate.norm               https://localhost:443/{a}/{b}/{c:.+}  thrpt   16     2976.000 ±     0.001    B/op
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Eden_Space           https://localhost:443/{a}/{b}/{c:.+}  thrpt   16     2355.653 ±    45.006  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Eden_Space.norm      https://localhost:443/{a}/{b}/{c:.+}  thrpt   16     2970.787 ±    22.520    B/op
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Survivor_Space       https://localhost:443/{a}/{b}/{c:.+}  thrpt   16        0.284 ±     0.049  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Survivor_Space.norm  https://localhost:443/{a}/{b}/{c:.+}  thrpt   16        0.358 ±     0.061    B/op
JerseyUriBuilderBenchmark.uri:·gc.count                         https://localhost:443/{a}/{b}/{c:.+}  thrpt   16      788.000              counts
JerseyUriBuilderBenchmark.uri:·gc.time                          https://localhost:443/{a}/{b}/{c:.+}  thrpt   16      367.000                  ms
```

After:
```
# Run complete. Total time: 00:02:41

Benchmark                                                                              (uriTemplate)   Mode  Cnt        Score        Error   Units
JerseyUriBuilderBenchmark.uri                                            http://localhost:8080/a/b/c  thrpt   16  2080011.734 ±  41688.766   ops/s
JerseyUriBuilderBenchmark.uri:·gc.alloc.rate                             http://localhost:8080/a/b/c  thrpt   16     1539.193 ±     30.853  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.alloc.rate.norm                        http://localhost:8080/a/b/c  thrpt   16      776.000 ±      0.001    B/op
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Eden_Space                    http://localhost:8080/a/b/c  thrpt   16     1538.979 ±     31.795  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Eden_Space.norm               http://localhost:8080/a/b/c  thrpt   16      775.911 ±      7.038    B/op
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Survivor_Space                http://localhost:8080/a/b/c  thrpt   16        0.293 ±      0.052  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Survivor_Space.norm           http://localhost:8080/a/b/c  thrpt   16        0.148 ±      0.025    B/op
JerseyUriBuilderBenchmark.uri:·gc.count                                  http://localhost:8080/a/b/c  thrpt   16      822.000               counts
JerseyUriBuilderBenchmark.uri:·gc.time                                   http://localhost:8080/a/b/c  thrpt   16      372.000                   ms
JerseyUriBuilderBenchmark.uri                                   https://localhost:443/{a}/{b}/{c:.+}  thrpt   16  1354535.963 ± 233642.829   ops/s
JerseyUriBuilderBenchmark.uri:·gc.alloc.rate                    https://localhost:443/{a}/{b}/{c:.+}  thrpt   16     1054.019 ±    181.806  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.alloc.rate.norm               https://localhost:443/{a}/{b}/{c:.+}  thrpt   16      816.000 ±      0.001    B/op
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Eden_Space           https://localhost:443/{a}/{b}/{c:.+}  thrpt   16     1053.837 ±    189.819  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Eden_Space.norm      https://localhost:443/{a}/{b}/{c:.+}  thrpt   16      814.624 ±     17.953    B/op
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Survivor_Space       https://localhost:443/{a}/{b}/{c:.+}  thrpt   16        0.275 ±      0.098  MB/sec
JerseyUriBuilderBenchmark.uri:·gc.churn.PS_Survivor_Space.norm  https://localhost:443/{a}/{b}/{c:.+}  thrpt   16        0.208 ±      0.056    B/op
JerseyUriBuilderBenchmark.uri:·gc.count                         https://localhost:443/{a}/{b}/{c:.+}  thrpt   16      662.000               counts
JerseyUriBuilderBenchmark.uri:·gc.time                          https://localhost:443/{a}/{b}/{c:.+}  thrpt   16      327.000                   ms
```