### PR TITLE
Adding support for opening EventSource with a pre-known eventId

### DIFF
--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/EventSource.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/EventSource.java
@@ -283,6 +283,20 @@ public class EventSource implements EventListener {
      * @throws IllegalStateException in case the event source has already been opened earlier.
      */
     public void open() {
+        open(null);
+    }
+
+    /**
+     * Open the connection to the supplied SSE underlying {@link WebTarget web
+     * target} and start processing incoming {@link InboundEvent events}
+     * beginning with the one last seen.
+     * 
+     * @param lastEventId
+     *            the id of the last event, the caller has seen before
+     * @throws IllegalStateException
+     *             in case the event source has already been opened earlier.
+     */
+    public void open(String lastEventId) {
         if (!state.compareAndSet(EventProcessor.State.READY, EventProcessor.State.OPEN)) {
             switch (state.get()) {
                 case OPEN:
@@ -297,6 +311,10 @@ public class EventSource implements EventListener {
                               .boundListeners(boundListeners)
                               .unboundListeners(unboundListeners)
                               .reconnectDelay(reconnectDelay, TimeUnit.MILLISECONDS);
+
+        if (lastEventId != null) {
+            builder.lastEventId(lastEventId);
+        }
 
         if (disableKeepAlive) {
             builder.disableKeepAlive();

--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/internal/EventProcessor.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/internal/EventProcessor.java
@@ -443,6 +443,15 @@ public class EventProcessor implements Runnable, EventListener {
             this.disableKeepAlive = true;
             return this;
         }
+        /**
+         * setting initial event id
+         * @param lastEventId
+         * @return
+         */
+        public Builder lastEventId(String lastEventId){
+            this.lastEventId = lastEventId;
+            return this;
+        }
 
         /**
          * Build the {@link EventProcessor}.


### PR DESCRIPTION
Hi,

I tried to use a jersey client with an SSE stream in following scenario: 

The client subscribes to the stream and persist the current eventId to a database.
After a restart, the client reads the persisted last id from the database and wants to reconnect to the stream with the pointer to the current event. This feature is already supported if the client looses his connection but unfortunately not for restarting the whole client. 

I added another open() method to the EventSource class, where you can pass the eventId to start from. 

It would be nice, if you could consider to merge this.

Thanks a lot.