### PR TITLE
Add default link style to DeclarativeLinkingFeature

### DIFF
--- a/docs/src/main/docbook/declarative-linking.xml
+++ b/docs/src/main/docbook/declarative-linking.xml
@@ -396,6 +396,58 @@ final Application application = new ResourceConfig()
         .packages("org.glassfish.jersey.examples.linking")
         .register(DeclarativeLinkingFeature.class);</programlisting>
             </example>
+
+            You can also change the default linking style for the whole application. Either by using the constructor of
+            <literal>DeclarativeLinkingFeature</literal>, or by setting the config value for
+            <literal>DeclarativeLinkingFeature.DEFAULT_LINK_STYLE</literal>.
+
+            <example>
+            <title>Creating JAX-RS application with Declarative Linking and default link style set to ABSOLUTE.</title>
+
+            <programlisting language="java">// Create JAX-RS application.
+final Application application = new ResourceConfig()
+        .packages("org.glassfish.jersey.examples.linking")
+        .register(new DeclarativeLinkingFeature(InjectLink.Style.ABSOLUTE));</programlisting>
+            </example>
+
+            The default value will be overridden if it is defined on the annotation
+            <literal>@InjectLink</literal>/<literal>@ProvideLink</literal>.
+
+        </para>
+
+        <para>
+            Possible values are:
+            <variablelist>
+                <varlistentry>
+                    <term>
+                        <literal>ABSOLUTE</literal>
+                    </term>
+                    <listitem>
+                        <para>
+                            An absolute URI. The URI template will be prefixed with the absolute base URI of the application.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <literal>ABSOLUTE_PATH</literal>
+                    </term>
+                    <listitem>
+                        <para>
+                            An absolute path. The URI template will be prefixed with the absolute base path of the application.
+                            This is also the <literal>DEFAULT</literal> behavior if nothing else is set.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <literal>RELATIVE_PATH</literal>
+                    </term>
+                    <listitem>
+                        <para>A relative path. The URI template will be converted to a relative path with no prefix.</para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
         </para>
     </section>
 </chapter>

--- a/examples/declarative-linking/src/main/java/org/glassfish/jersey/examples/linking/representation/ItemsRepresentation.java
+++ b/examples/declarative-linking/src/main/java/org/glassfish/jersey/examples/linking/representation/ItemsRepresentation.java
@@ -56,7 +56,6 @@ import org.glassfish.jersey.examples.linking.model.ItemsModel;
 import org.glassfish.jersey.examples.linking.resources.ItemsResource;
 import org.glassfish.jersey.linking.Binding;
 import org.glassfish.jersey.linking.InjectLink;
-import org.glassfish.jersey.linking.InjectLink.Style;
 import org.glassfish.jersey.linking.InjectLinks;
 
 /**
@@ -70,7 +69,6 @@ import org.glassfish.jersey.linking.InjectLinks;
 @InjectLinks({
         @InjectLink(
                 resource = ItemsResource.class,
-                style = Style.ABSOLUTE,
                 method = "query",
                 condition = "${instance.offset + instance.limit < instance.modelLimit}",
                 bindings = {
@@ -81,7 +79,6 @@ import org.glassfish.jersey.linking.InjectLinks;
         ),
         @InjectLink(
                 resource = ItemsResource.class,
-                style = Style.ABSOLUTE,
                 method = "query",
                 condition = "${instance.offset - instance.limit >= 0}",
                 bindings = {
@@ -105,7 +102,6 @@ public class ItemsRepresentation {
     @InjectLink(
             resource = ItemsResource.class,
             method = "query",
-            style = Style.ABSOLUTE,
             bindings = {@Binding(name = "offset", value = "${instance.offset}"),
                     @Binding(name = "limit", value = "${instance.limit}")
             },
@@ -118,7 +114,6 @@ public class ItemsRepresentation {
     @InjectLinks({
             @InjectLink(
                     resource = ItemsResource.class,
-                    style = Style.ABSOLUTE,
                     method = "query",
                     condition = "${instance.offset + instance.limit < instance.modelLimit}",
                     bindings = {
@@ -129,7 +124,6 @@ public class ItemsRepresentation {
             ),
             @InjectLink(
                     resource = ItemsResource.class,
-                    style = Style.ABSOLUTE,
                     method = "query",
                     condition = "${instance.offset - instance.limit >= 0}",
                     bindings = {

--- a/examples/declarative-linking/src/test/java/org/glassfish/jersey/examples/linking/LinkWebAppTest.java
+++ b/examples/declarative-linking/src/test/java/org/glassfish/jersey/examples/linking/LinkWebAppTest.java
@@ -47,6 +47,7 @@ import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.examples.linking.resources.ItemsResource;
 import org.glassfish.jersey.linking.DeclarativeLinkingFeature;
+import org.glassfish.jersey.linking.InjectLink;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
@@ -66,7 +67,7 @@ public class LinkWebAppTest extends JerseyTest {
     protected ResourceConfig configure() {
         enable(TestProperties.LOG_TRAFFIC);
         final ResourceConfig rc = new ResourceConfig(ItemsResource.class);
-        rc.register(DeclarativeLinkingFeature.class);
+        rc.register(new DeclarativeLinkingFeature(InjectLink.Style.ABSOLUTE));
         return rc;
     }
 

--- a/incubator/declarative-linking/pom.xml
+++ b/incubator/declarative-linking/pom.xml
@@ -106,6 +106,11 @@
             <version>1.4.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/DeclarativeLinkingFeature.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/DeclarativeLinkingFeature.java
@@ -62,10 +62,36 @@ import org.glassfish.jersey.linking.mapping.ResourceMappingContext;
 @Beta
 public class DeclarativeLinkingFeature implements Feature {
 
+    /**
+     * Sets the default link Style for this feature, see {@link InjectLink.Style} for the possible values.
+     */
+    public static final String DEFAULT_LINK_STYLE = "org.glassfish.jersey.linking.default.link.style";
+
+    private final InjectLink.Style defaultLinkStyle;
+
+    public DeclarativeLinkingFeature(InjectLink.Style defaultLinkStyle) {
+
+        this.defaultLinkStyle = defaultLinkStyle;
+    }
+
+    public DeclarativeLinkingFeature(){
+        this(null);
+    }
+
     @Override
     public boolean configure(FeatureContext context) {
 
         Configuration config = context.getConfiguration();
+
+        Object linkStyle = (defaultLinkStyle == null) ? config.getProperty(DEFAULT_LINK_STYLE) : defaultLinkStyle;
+        if (linkStyle instanceof String) {
+            context.property(DEFAULT_LINK_STYLE, InjectLink.Style.valueOf(((String) linkStyle).toUpperCase()));
+        } else if (linkStyle instanceof InjectLink.Style){
+            context.property(DEFAULT_LINK_STYLE, linkStyle);
+        } else if (linkStyle == null) {
+            context.property(DEFAULT_LINK_STYLE, InjectLink.Style.DEFAULT);
+        }
+
         if (!config.isRegistered(ResponseLinkFilter.class)) {
             context.register(new AbstractBinder() {
 

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/ELLinkBuilder.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/ELLinkBuilder.java
@@ -119,19 +119,24 @@ final class ELLinkBuilder {
         template = expr.getValue(context).toString();
 
         // now process any embedded URI template parameters
-        UriBuilder ub = applyLinkStyle(template, link.getLinkStyle(), uriInfo);
+        UriBuilder ub = applyLinkStyle(template, link.getLinkStyle(), rmc.getLinkStyle(), uriInfo);
         UriTemplateParser parser = new UriTemplateParser(template);
         List<String> parameterNames = parser.getNames();
         Map<String, Object> valueMap = getParameterValues(parameterNames, link, context, uriInfo);
         return ub.buildFromMap(valueMap);
     }
 
-    private static UriBuilder applyLinkStyle(String template, InjectLink.Style style, UriInfo uriInfo) {
+    private static UriBuilder applyLinkStyle(String template,
+            InjectLink.Style linkStyle,
+            InjectLink.Style contextStyle,
+            UriInfo uriInfo) {
         UriBuilder ub = null;
+        InjectLink.Style style = (linkStyle == InjectLink.Style.DEFAULT) ? contextStyle : linkStyle;
         switch (style) {
             case ABSOLUTE:
                 ub = uriInfo.getBaseUriBuilder().path(template);
                 break;
+            case DEFAULT:
             case ABSOLUTE_PATH:
                 String basePath = uriInfo.getBaseUri().getPath();
                 ub = UriBuilder.fromPath(basePath).path(template);

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLink.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/InjectLink.java
@@ -81,14 +81,20 @@ public @interface InjectLink {
          * A relative path. The URI template will be converted to a relative
          * path with no prefix.
          */
-        RELATIVE_PATH
+        RELATIVE_PATH,
+
+        /**
+         * Default style which can be configured for all links by {@link DeclarativeLinkingFeature#DEFAULT_LINK_STYLE}.
+         * If both are {@code DEFAULT} then it will use the {@link #ABSOLUTE_PATH} style.
+         */
+        DEFAULT
 
     }
 
     /**
      * The style of URI to inject
      */
-    Style style() default Style.ABSOLUTE_PATH;
+    Style style() default Style.DEFAULT;
 
     /**
      * Specifies a URI template that will be used to build the injected URI. The

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/ProvideLink.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/ProvideLink.java
@@ -79,7 +79,7 @@ public @interface ProvideLink {
     /**
      * The style of URI to inject
      */
-    InjectLink.Style style() default InjectLink.Style.ABSOLUTE_PATH;
+    InjectLink.Style style() default InjectLink.Style.DEFAULT;
 
     /**
      * Provide links for representation classes listed here.

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/mapping/NaiveResourceMappingContext.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/mapping/NaiveResourceMappingContext.java
@@ -46,9 +46,11 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
+import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Context;
 
+import org.glassfish.jersey.linking.DeclarativeLinkingFeature;
+import org.glassfish.jersey.linking.InjectLink;
 import org.glassfish.jersey.process.Inflector;
 import org.glassfish.jersey.server.ExtendedResourceContext;
 import org.glassfish.jersey.server.model.HandlerConstructor;
@@ -76,14 +78,22 @@ public class NaiveResourceMappingContext implements ResourceMappingContext {
 
     private Map<Class<?>, ResourceMappingContext.Mapping> mappings;
 
-    public NaiveResourceMappingContext(@Context final ExtendedResourceContext erc) {
+    private final InjectLink.Style linkStyle;
+
+    public NaiveResourceMappingContext(@Context final ExtendedResourceContext erc, @Context Configuration configuration) {
         this.erc = erc;
+        this.linkStyle = (InjectLink.Style) configuration.getProperty(DeclarativeLinkingFeature.DEFAULT_LINK_STYLE);
     }
 
     @Override
     public Mapping getMapping(final Class<?> resource) {
         buildMappings();
         return mappings.get(resource);
+    }
+
+    @Override
+    public InjectLink.Style getLinkStyle() {
+        return linkStyle;
     }
 
     private void buildMappings() {

--- a/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/mapping/ResourceMappingContext.java
+++ b/incubator/declarative-linking/src/main/java/org/glassfish/jersey/linking/mapping/ResourceMappingContext.java
@@ -40,6 +40,7 @@
 
 package org.glassfish.jersey.linking.mapping;
 
+import org.glassfish.jersey.linking.InjectLink;
 import org.glassfish.jersey.uri.UriTemplate;
 
 /**
@@ -51,10 +52,12 @@ import org.glassfish.jersey.uri.UriTemplate;
 
 public interface ResourceMappingContext {
 
-    public interface Mapping {
+    interface Mapping {
 
-        public UriTemplate getTemplate();
+        UriTemplate getTemplate();
     }
 
-    public Mapping getMapping(Class<?> resource);
+    Mapping getMapping(Class<?> resource);
+
+    InjectLink.Style getLinkStyle();
 }

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/EntityDescriptorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/EntityDescriptorTest.java
@@ -75,6 +75,11 @@ public class EntityDescriptorTest {
         public ResourceMappingContext.Mapping getMapping(Class<?> resource) {
             return null;
         }
+
+        @Override
+        public InjectLink.Style getLinkStyle() {
+            return InjectLink.Style.DEFAULT;
+        }
     };
 
     /**

--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/HeaderProcessorTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/HeaderProcessorTest.java
@@ -223,6 +223,11 @@ public class HeaderProcessorTest {
         public ResourceMappingContext.Mapping getMapping(Class<?> resource) {
             return null;
         }
+
+        @Override
+        public InjectLink.Style getLinkStyle() {
+            return InjectLink.Style.DEFAULT;
+        }
     };
 
     @InjectLink(value = "A")


### PR DESCRIPTION
This adds the option to set a default link style for the whole
application without the need to change every annotation.