### PR TITLE
Fix IndexOutOfBoundsException in ReflectionHelper for methods named "get"

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/ReflectionHelper.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/ReflectionHelper.java
@@ -963,9 +963,13 @@ public final class ReflectionHelper {
         final int offset = methodName.startsWith("is") ? 2 : 3;
 
         final char[] chars = methodName.toCharArray();
-        chars[offset] = Character.toLowerCase(chars[offset]);
 
-        return new String(chars, offset, chars.length - offset);
+        if (offset < chars.length) {
+            chars[offset] = Character.toLowerCase(chars[offset]);
+            return new String(chars, offset, chars.length - offset);
+        } else {
+            return "";
+        }
     }
 
     /**

--- a/core-common/src/test/java/org/glassfish/jersey/internal/util/ReflectionHelperTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/internal/util/ReflectionHelperTest.java
@@ -44,9 +44,7 @@ import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import org.glassfish.jersey.internal.util.collection.Ref;
 import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -101,8 +99,7 @@ public class ReflectionHelperTest {
         final ClassLoader loader = ReflectionHelper.class.getClassLoader();
 
         ReflectionHelper.setContextClassLoaderPA(loader).run();
-        fail("It should not be possible to set context class loader from unprivileged block even via Jersey "
-                     + "ReflectionHelper");
+        fail("It should not be possible to set context class loader from unprivileged block even via Jersey ReflectionHelper");
     }
 
     @Test(expected = AccessControlException.class)
@@ -110,8 +107,7 @@ public class ReflectionHelperTest {
         final ClassLoader loader = ReflectionHelper.class.getClassLoader();
 
         AccessController.doPrivileged(ReflectionHelper.setContextClassLoaderPA(loader));
-        fail("It should not be possible to set context class loader even from privileged block via Jersey "
-                     + "ReflectionHelper "
+        fail("It should not be possible to set context class loader even from privileged block via Jersey ReflectionHelper "
                      + "utility");
     }
 
@@ -165,8 +161,7 @@ public class ReflectionHelperTest {
      */
     @Test
     public void testGetValueOfStringMethodNegative() throws Exception {
-        final PrivilegedAction<Method> methodPA = ReflectionHelper.getValueOfStringMethodPA(
-                InvalidFromStringClass.class);
+        final PrivilegedAction<Method> methodPA = ReflectionHelper.getValueOfStringMethodPA(InvalidFromStringClass.class);
 
         assertThat("Invalid valueOf method found.", methodPA.run(), nullValue());
     }
@@ -187,8 +182,7 @@ public class ReflectionHelperTest {
      */
     @Test
     public void testGetFromStringStringMethodNegative() throws Exception {
-        final PrivilegedAction<Method> methodPA = ReflectionHelper.getFromStringStringMethodPA(
-                InvalidFromStringClass.class);
+        final PrivilegedAction<Method> methodPA = ReflectionHelper.getFromStringStringMethodPA(InvalidFromStringClass.class);
 
         assertThat("Invalid valueOf method found.", methodPA.run(), nullValue());
     }

--- a/core-common/src/test/java/org/glassfish/jersey/internal/util/ReflectionHelperTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/internal/util/ReflectionHelperTest.java
@@ -44,7 +44,9 @@ import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import org.glassfish.jersey.internal.util.collection.Ref;
 import org.junit.Test;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -99,7 +101,8 @@ public class ReflectionHelperTest {
         final ClassLoader loader = ReflectionHelper.class.getClassLoader();
 
         ReflectionHelper.setContextClassLoaderPA(loader).run();
-        fail("It should not be possible to set context class loader from unprivileged block even via Jersey ReflectionHelper");
+        fail("It should not be possible to set context class loader from unprivileged block even via Jersey "
+                     + "ReflectionHelper");
     }
 
     @Test(expected = AccessControlException.class)
@@ -107,8 +110,9 @@ public class ReflectionHelperTest {
         final ClassLoader loader = ReflectionHelper.class.getClassLoader();
 
         AccessController.doPrivileged(ReflectionHelper.setContextClassLoaderPA(loader));
-        fail("It should not be possible to set context class loader even from privileged block via Jersey ReflectionHelper "
-                + "utility");
+        fail("It should not be possible to set context class loader even from privileged block via Jersey "
+                     + "ReflectionHelper "
+                     + "utility");
     }
 
     public static class FromStringClass {
@@ -161,7 +165,8 @@ public class ReflectionHelperTest {
      */
     @Test
     public void testGetValueOfStringMethodNegative() throws Exception {
-        final PrivilegedAction<Method> methodPA = ReflectionHelper.getValueOfStringMethodPA(InvalidFromStringClass.class);
+        final PrivilegedAction<Method> methodPA = ReflectionHelper.getValueOfStringMethodPA(
+                InvalidFromStringClass.class);
 
         assertThat("Invalid valueOf method found.", methodPA.run(), nullValue());
     }
@@ -182,8 +187,33 @@ public class ReflectionHelperTest {
      */
     @Test
     public void testGetFromStringStringMethodNegative() throws Exception {
-        final PrivilegedAction<Method> methodPA = ReflectionHelper.getFromStringStringMethodPA(InvalidFromStringClass.class);
+        final PrivilegedAction<Method> methodPA = ReflectionHelper.getFromStringStringMethodPA(
+                InvalidFromStringClass.class);
 
         assertThat("Invalid valueOf method found.", methodPA.run(), nullValue());
+    }
+
+    @Test
+    public void testForPropertyNameNormalGetter() throws Exception {
+        class TestGet {
+            public int getProp() {
+                return 1;
+            }
+        }
+        Method method = TestGet.class.getMethod("getProp");
+        final String propertyName = ReflectionHelper.getPropertyName(method);
+        assertThat("getPropertyName should extract the correct property", propertyName, is("prop"));
+    }
+
+    @Test
+    public void testForPropertyNameOfGetMethod() throws Exception {
+        class TestGet {
+            public int get() {
+                return 0;
+            }
+        }
+        Method method = TestGet.class.getMethod("get");
+        String propertyName = ReflectionHelper.getPropertyName(method);
+        assertThat("get method should not have a property name", propertyName, is(""));
     }
 }


### PR DESCRIPTION
When annotating response objects with @RolesAllowed and enabling the SecurityEntityFilteringFeature, jersey will throw an IndexOutOfBoundsException when scanning the properties for (nested) objects which contain a method just named "get" (without an actual property name after the get).

 In my case, this is a Mongo ObjectId instance (for which a custom mapper has been registered).

The cause is in the ReflectionHelper method getMethodName, which does not take this edge case into account. I've created a fix and a test for this issue.

Let me know if you need more information.

Kind Regards,

Pieter van Prooijen
