### PR TITLE
Added recommended space after semicolon in content-type header

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/MediaTypeProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/MediaTypeProvider.java
@@ -76,7 +76,7 @@ public class MediaTypeProvider implements HeaderDelegateProvider<MediaType> {
         StringBuilder b = new StringBuilder();
         b.append(header.getType()).append('/').append(header.getSubtype());
         for (Map.Entry<String, String> e : header.getParameters().entrySet()) {
-            b.append(";").append(e.getKey()).append('=');
+            b.append("; ").append(e.getKey()).append('=');
             StringBuilderUtils.appendQuotedIfNonToken(b, e.getValue());
         }
         return b.toString();


### PR DESCRIPTION
added the recommended space after the semicolon on mediatype provider
this will 'fix' #3606, a regression of #909