### PR TITLE
Fix ReflectionHelper.isGetter - methods named 'get' and 'is' are not getters.

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/ReflectionHelper.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/ReflectionHelper.java
@@ -905,9 +905,9 @@ public final class ReflectionHelper {
                 && Modifier.isPublic(method.getModifiers())) {
             final String methodName = method.getName();
 
-            if (methodName.startsWith("get")) {
+            if (methodName.startsWith("get") && methodName.length() > 3) {
                 return !void.class.equals(method.getReturnType());
-            } else if (methodName.startsWith("is")) {
+            } else if (methodName.startsWith("is") && methodName.length() > 2) {
                 return boolean.class.equals(method.getReturnType()) || Boolean.class.equals(method.getReturnType());
             }
         }

--- a/core-common/src/test/java/org/glassfish/jersey/internal/util/ReflectionHelperTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/internal/util/ReflectionHelperTest.java
@@ -46,6 +46,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import org.junit.Test;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -186,5 +187,48 @@ public class ReflectionHelperTest {
         final PrivilegedAction<Method> methodPA = ReflectionHelper.getFromStringStringMethodPA(InvalidFromStringClass.class);
 
         assertThat("Invalid valueOf method found.", methodPA.run(), nullValue());
+    }
+
+    public static class IsGetterTester {
+
+        public int get() {
+            return 0;
+        }
+
+        public boolean is() {
+            return true;
+        }
+
+        public int getSomething() {
+            return 0;
+        }
+
+        public boolean isSomething() {
+            return true;
+        }
+    }
+
+    @Test
+    public void testIsGetterWithGetOnlyNegative() throws Exception {
+        assertThat("isGetter should have returned false for method named 'get'",
+                ReflectionHelper.isGetter(IsGetterTester.class.getMethod("get")), is(false));
+    }
+
+    @Test
+    public void testIsGetterWithIsOnlyNegative() throws Exception {
+        assertThat("isGetter should have returned false for method named 'is'",
+                ReflectionHelper.isGetter(IsGetterTester.class.getMethod("is")), is(false));
+    }
+
+    @Test
+    public void testIsGetterWithRealGetterPositive() throws Exception {
+        assertThat("isGetter should have returned true for method named 'getSomething'",
+                ReflectionHelper.isGetter(IsGetterTester.class.getMethod("getSomething")), is(true));
+    }
+
+    @Test
+    public void testIsGetterWithRealIsPositive() throws Exception {
+        assertThat("isGetter should have returned true for method named 'isSomething'",
+                ReflectionHelper.isGetter(IsGetterTester.class.getMethod("isSomething")), is(true));
     }
 }


### PR DESCRIPTION
Currently, ReflectionHelper.isGetter is used by the (relatively) new Jackson JSON feature module to populate a list of all possible getters for later filtering. During the filtering stage, entity writers then attempt to calculate the "field" name from the method, but if the method is "get" or "is", it passes as a getter, but will cause an exception in ReflectionHelper.getMethodName because it tries to change the character beyond the last one ('t') to lower case. The fact is, methods named 'get' and 'is' are not really getters, even though they fit the general pattern from a functionality perspective because the item they're getting is implied by context and cannot be determined by external entities.

(Note to maintainers: I submitted my OCA to Oracle earlier today via email.)