### PR TITLE
Fix jersey-netty-connector to allow unauthenticated proxies

### DIFF
--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyConnector.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyConnector.java
@@ -193,9 +193,12 @@ class NettyConnector implements Connector {
                          final String password = ClientProperties.getValue(
                                  config.getProperties(), ClientProperties.PROXY_PASSWORD, String.class);
 
-                         p.addLast(new HttpProxyHandler(new InetSocketAddress(u.getHost(),
-                                                                              u.getPort() == -1 ? 8080 : u.getPort()),
-                                                        userName, password));
+                         InetSocketAddress proxyAddress = new InetSocketAddress(u.getHost(), u.getPort() == -1 ? 8080 : u.getPort());
+
+                         HttpProxyHandler httpProxyHandler = ((userName == null) || (password == null)) ?
+                                 new HttpProxyHandler(proxyAddress) :
+                                 new HttpProxyHandler(proxyAddress, userName, password);
+                         p.addLast(httpProxyHandler);
                      }
 
                      p.addLast(new HttpClientCodec());


### PR DESCRIPTION
Nettys `io.netty.handler.proxy.HttpProxyHandler#HttpProxyHandler(java.net.SocketAddress, java.lang.String, java.lang.String)` will throw an NPE if called with either `username` or `password` as null. So use `io.netty.handler.proxy.HttpProxyHandler#HttpProxyHandler(java.net.SocketAddress)` instead if either of them are null.