### PR TITLE
ParamConverterFactory should use LinkedHashSet to preserve ordering

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/inject/ParamConverterFactory.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/inject/ParamConverterFactory.java
@@ -43,7 +43,7 @@ package org.glassfish.jersey.server.internal.inject;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -73,7 +73,7 @@ public class ParamConverterFactory implements ParamConverterProvider {
 
     ParamConverterFactory(Set<ParamConverterProvider> providers, Set<ParamConverterProvider> customProviders) {
 
-        Set<ParamConverterProvider> copyProviders = new HashSet<>(providers);
+        Set<ParamConverterProvider> copyProviders = new LinkedHashSet<>(providers);
         converterProviders = new ArrayList<>();
         converterProviders.addAll(customProviders);
         copyProviders.removeAll(customProviders);


### PR DESCRIPTION
The class `ParamConverterFactory` manages a list of `ParamConverterProvider` implementations. But unfortunately the order in which the providers are processed seems to change between deployments. The reason for this is that the factory uses a `HashSet` internally. The provider sets passed into the constructor are `LinkedHashSet` instances, but as they are copied to the `HashSet`, the order may change.