### PR TITLE
Fix "sse-item-store-*-webapp" samples

### DIFF
--- a/examples/sse-item-store-jaxrs-webapp/src/main/webapp/js/engine.js
+++ b/examples/sse-item-store-jaxrs-webapp/src/main/webapp/js/engine.js
@@ -89,7 +89,7 @@ function receiveMessages() {
             display("Added new item: " + event.data, "#444444");
         };
 
-        source.addEventListener("size", function(e) {
+        source.addEventListener("size", function (event) {
             console.log('Received event ' + event.name + ': ' + event.data);
             display("New items size: " + event.data, "#0000FF");
         }, false);

--- a/examples/sse-item-store-jersey-webapp/src/main/webapp/js/engine.js
+++ b/examples/sse-item-store-jersey-webapp/src/main/webapp/js/engine.js
@@ -89,7 +89,7 @@ function receiveMessages() {
             display("Added new item: " + event.data, "#444444");
         };
 
-        source.addEventListener("size", function(e) {
+        source.addEventListener("size", function (event) {
             console.log('Received event ' + event.name + ': ' + event.data);
             display("New items size: " + event.data, "#0000FF");
         }, false);


### PR DESCRIPTION
While on Chrome the problem is not visible, on Firefox the "New items size: ..." message is not shown due to the ReferenceError (i.e. `ReferenceError: event is not defined`).

For the sake of completeness, this fix was already verified [here](https://github.com/jersey/jersey/pull/213).