### PR TITLE
#3293 Pre-load default ssl socket factory in HttpUrlConnector

### DIFF
--- a/tests/e2e-client/src/test/java/org/glassfish/jersey/tests/e2e/client/connector/ssl/SslHttpUrlConnectorTest.java
+++ b/tests/e2e-client/src/test/java/org/glassfish/jersey/tests/e2e/client/connector/ssl/SslHttpUrlConnectorTest.java
@@ -40,26 +40,32 @@
 
 package org.glassfish.jersey.tests.e2e.client.connector.ssl;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.InetAddress;
-import java.net.Socket;
-import java.net.URL;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Response;
-
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.jersey.logging.LoggingFeature;
-
 import org.junit.Test;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -101,6 +107,59 @@ public class SslHttpUrlConnectorTest extends AbstractConnectorServerTest {
         final Response response = client.target(Server.BASE_URI).path("/").request().get();
         assertEquals(200, response.getStatus());
         assertTrue(socketFactory.isVisited());
+    }
+
+    /**
+     * Test for https://github.com/jersey/jersey/issues/3293
+     */
+    @Test
+    public void testConcurrentRequestsWithCustomSSLContext() throws Exception {
+        final SSLContext sslContext = getSslContext();
+
+        final Client client = ClientBuilder.newBuilder()
+            .sslContext(sslContext)
+            .register(HttpAuthenticationFeature.basic("user", "password"))
+            .register(LoggingFeature.class)
+            .build();
+
+        int numThreads = 5;
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        List<Exception> exceptions = new CopyOnWriteArrayList<>();
+
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(() -> {
+                try {
+                    barrier.await(1, TimeUnit.MINUTES);
+                    for (int call = 0; call < 10; call++) {
+                        final Response response = client.target(Server.BASE_URI).path("/").request().get();
+                        assertEquals(200, response.getStatus());
+                    }
+                } catch (Exception ex) {
+                    exceptions.add(ex);
+                }
+            });
+        }
+
+        service.shutdown();
+
+        assertTrue(
+            service.awaitTermination(1, TimeUnit.MINUTES)
+        );
+
+        assertTrue(
+            toString(exceptions),
+            exceptions.isEmpty()
+        );
+    }
+
+    private String toString(List<Exception> exceptions) {
+        StringWriter writer = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(writer);
+
+        exceptions.forEach(e -> e.printStackTrace(printWriter));
+
+        return writer.toString();
     }
 
     public static class CustomSSLSocketFactory extends SSLSocketFactory {


### PR DESCRIPTION
@mpotociar @petrbouda this PR is a potential fix for #3293

From my understanding of the current code, the logic for using a custom SSL socket factory is:

1. If the `HttpsUrlConnection` returned by the `ConnectionFactory` already has a custom `SSLSocketFactory` set on it, do nothing
1. Otherwise, set the socket factory on the connection to be the one provided from the `SSLContext` in the client config.

Currently, the [first check](https://github.com/jersey/jersey/blob/2.26/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java#L325) is done via:

```java
if (HttpsURLConnection.getDefaultSSLSocketFactory() == suc.getSSLSocketFactory()) {
    // indicates that the custom socket factory was not set
    suc.setSSLSocketFactory(sslSocketFactory.get());
}
```

The issue with this code is that `HttpsURLConnection.getDefaultSSLSocketFactory() ` is not thread safe.  The implementation looks like:

```java
    public static SSLSocketFactory getDefaultSSLSocketFactory() {
        if (defaultSSLSocketFactory == null) {
            defaultSSLSocketFactory = (SSLSocketFactory)SSLSocketFactory.getDefault();
        }

        return defaultSSLSocketFactory;
    }
```

If there are concurrent requests, one of them may end up creating a separate `SSLSocketFactory` that is not the default.  The comparison check above fails and the request ends up using the default SSL context instead of the provided one.

The fix in this PR is to call `HttpsURLConnection.getDefaultSSLSocketFactory()` in a static initializer block for the class so that the default SSLContext is present when the comparison is made in `HttpUrlConnector#secureConnector`

I'm open to feedback on alternate approaches to resolving this.