### PR TITLE
Ensure cookie is added to request when Cookie object name matches annotation name

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -262,14 +262,15 @@ public final class WebResourceFactory implements InvocationHandler {
                             }
                         } else {
                             if (!(value instanceof Cookie)) {
-                                cookies.add(new Cookie(name, value.toString()));
+                                c = new Cookie(name, value.toString());
                             } else {
                                 c = (Cookie) value;
                                 if (!name.equals(((Cookie) value).getName())) {
                                     // is this the right thing to do? or should I fail? or ignore the difference?
-                                    cookies.add(new Cookie(name, c.getValue(), c.getPath(), c.getDomain(), c.getVersion()));
+                                    c = new Cookie(name, c.getValue(), c.getPath(), c.getDomain(), c.getVersion());
                                 }
                             }
+                            cookies.add(c);
                         }
                     } else if ((ann = anns.get((MatrixParam.class))) != null) {
                         if (value instanceof Collection) {

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
@@ -41,6 +41,7 @@
 package org.glassfish.jersey.client.proxy;
 
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
@@ -80,6 +81,11 @@ public class MyResource implements MyResourceIfc {
     @Override
     public String getByNameCookie(String name) {
         return name;
+    }
+
+    @Override
+    public String getByNameCookie(Cookie cookie) {
+        return cookie.getValue();
     }
 
     @Override

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
@@ -57,6 +57,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
@@ -91,6 +92,11 @@ public interface MyResourceIfc {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     String getByNameCookie(@CookieParam("cookie-name") String name);
+
+    @Path("cookie-object")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    String getByNameCookie(@CookieParam("cookie-name") Cookie cookie);
 
     @Path("header")
     @GET

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -138,6 +138,16 @@ public class WebResourceFactoryTest extends JerseyTest {
     }
 
     @Test
+    public void testCookieParamAsCookie() {
+        assertEquals("cocobey", resource.getByNameCookie(new Cookie("cookie-name", "cocobey")));
+    }
+
+    @Test
+    public void testCookieParamAsCookieWithWrongName() {
+        assertEquals("cocobey", resource.getByNameCookie(new Cookie("wrong-name", "cocobey")));
+    }
+
+    @Test
     public void testHeaderParam() {
         assertEquals("jiri", resource.getByNameHeader("jiri"));
     }


### PR DESCRIPTION
If the CookieParam is a Cookie object, ensure it is added to the request when the cookie name matches CookieParam name