### PR TITLE
Added missing services registration file for ApacheConnectorProvider

### DIFF
--- a/connectors/apache-connector/src/main/resources/META-INF/services/org.glassfish.jersey.client.spi.ConnectorProvider
+++ b/connectors/apache-connector/src/main/resources/META-INF/services/org.glassfish.jersey.client.spi.ConnectorProvider
@@ -1,0 +1,1 @@
+org.glassfish.jersey.apache.connector.ApacheConnectorProvider


### PR DESCRIPTION
Jersey ClientConfig class was updated to support custom ConnectionProvider which are made available through SPI interface "org.glassfish.jersey.client.spi.ConnectorProvider", see Class ClientConfig lines 148ff.

Unfortunately the ApacheConnectorProvider module misses the necessary SPI registration file in order to provide the ApacheConnectorProvider at runtime without to explicitely have to register the connector provider within the ClientConfig instance.

