### PR TITLE
Let htmljson module use Apache HTML/Java API version 1.5.1

### DIFF
--- a/incubator/html-json/pom.xml
+++ b/incubator/html-json/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.26-SNAPSHOT</version>
+        <version>2.27-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.jersey.media</groupId>
@@ -62,7 +62,7 @@
     </description>
 
     <properties>
-        <net.java.html.version>1.0</net.java.html.version>
+        <net.java.html.version>1.5.1</net.java.html.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Few years ago I donated an implementation of 'MessageBodyReader` and `MessageBodyWriter` using NetBeans HTML/Java JSON persistence library as an `htmljson` incubating module. Time has passed and this library is now part of _Apache NetBeans_ (incubating) project: [Read more](https://github.com/apache/incubator-netbeans-html4j#readme)...

I'd like to update the Jersey project to use the latest and greatest version of the library - version 1.5.1. Please consider my change.