### PR TITLE
Support HttpServletRequest/Response in Jetty

### DIFF
--- a/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
+++ b/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
@@ -103,6 +103,9 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     private static final Type REQUEST_TYPE = (new GenericType<Ref<Request>>() {}).getType();
     private static final Type RESPONSE_TYPE = (new GenericType<Ref<Response>>() {}).getType();
 
+    private static final Type HTTP_SERVLET_REQUEST_TYPE = (new GenericType<Ref<HttpServletRequest>>() {}).getType();
+    private static final Type HTTP_SERVLET_RESPONSE_TYPE = (new GenericType<Ref<HttpServletResponse>>() {}).getType();
+
     private static final int INTERNAL_SERVER_ERROR = javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
 
     /**
@@ -123,11 +126,31 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     }
 
     /**
+     * Referencing factory for HttpServletRequest.
+     */
+    private static class HttpServletRequestReferencingFactory extends ReferencingFactory<HttpServletRequest> {
+        @Inject
+        public HttpServletRequestReferencingFactory(final Provider<Ref<HttpServletRequest>> referenceFactory) {
+            super(referenceFactory);
+        }
+    }
+
+    /**
      * Referencing factory for Jetty response.
      */
     private static class JettyResponseReferencingFactory extends ReferencingFactory<Response> {
         @Inject
         public JettyResponseReferencingFactory(final Provider<Ref<Response>> referenceFactory) {
+            super(referenceFactory);
+        }
+    }
+
+    /**
+     * Referencing factory for HttpServletResponse.
+     */
+    private static class HttpServletResponseReferencingFactory extends ReferencingFactory<HttpServletResponse> {
+        @Inject
+        public HttpServletResponseReferencingFactory(final Provider<Ref<HttpServletResponse>> referenceFactory) {
             super(referenceFactory);
         }
     }
@@ -148,10 +171,20 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
             bindFactory(ReferencingFactory.<Request>referenceFactory()).to(new GenericType<Ref<Request>>() {})
                     .in(RequestScoped.class);
 
+            bindFactory(HttpServletRequestReferencingFactory.class).to(HttpServletRequest.class)
+                    .proxy(true).proxyForSameScope(false).in(RequestScoped.class);
+            bindFactory(ReferencingFactory.<HttpServletRequest>referenceFactory())
+                    .to(new GenericType<Ref<HttpServletRequest>>() {}).in(RequestScoped.class);
+
             bindFactory(JettyResponseReferencingFactory.class).to(Response.class)
                     .proxy(false).in(RequestScoped.class);
             bindFactory(ReferencingFactory.<Response>referenceFactory()).to(new GenericType<Ref<Response>>() {})
                     .in(RequestScoped.class);
+
+            bindFactory(HttpServletResponseReferencingFactory.class).to(HttpServletResponse.class)
+                    .proxy(true).proxyForSameScope(false).in(RequestScoped.class);
+            bindFactory(ReferencingFactory.<HttpServletResponse>referenceFactory())
+                    .to(new GenericType<Ref<HttpServletResponse>>() {}).in(RequestScoped.class);
         }
     }
 

--- a/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ContextTest.java
+++ b/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ContextTest.java
@@ -1,0 +1,96 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2013-2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.jetty;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.jetty.server.Request;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ContextTest extends AbstractJettyServerTester {
+    @Path("/context")
+    public static class ContextResource {
+        @GET
+        @Path("/jetty")
+        public String jetty(@Context Request req, @Context org.eclipse.jetty.server.Response resp) {
+            resp.addHeader("x-test", req.getHeader("x-test"));
+            return "DONE";
+        }
+
+        @GET
+        @Path("/servlet-http")
+        public String httpServlet(@Context HttpServletRequest req, @Context HttpServletResponse resp) {
+            resp.addHeader("x-test", req.getHeader("x-test"));
+            return "DONE";
+        }
+    }
+
+    @Test
+    public void testJetty() {
+        startServer(ContextResource.class);
+        final Client client = ClientBuilder.newClient();
+        final Response response = client.target(getUri().path("/context/jetty")).request()
+                .header("x-test", "jetty").get();
+        final String entity = response.readEntity(String.class);
+        assertEquals("DONE", entity);
+        assertEquals("jetty", response.getHeaderString("x-test"));
+    }
+
+    @Test
+    public void testHttpServlet() {
+        startServer(ContextResource.class);
+        final Client client = ClientBuilder.newClient();
+        final Response response = client.target(getUri().path("/context/servlet-http")).request()
+                .header("x-test", "servlet-http").get();
+        final String entity = response.readEntity(String.class);
+        assertEquals("DONE", entity);
+        assertEquals("servlet-http", response.getHeaderString("x-test"));
+    }
+}


### PR DESCRIPTION
Support injection of `HttpServletRequest` and `HttpServletResponse` in addition to the Jetty-specific `Request` and `Response` objects, which already implement those interfaces.

(I am listed for Jersey in the [Oracle Contributor Agreement](http://www.oracle.com/technetwork/community/oca-486395.html#w) under "Workiva Inc.")