### PR TITLE
Fix Jetty context path

### DIFF
--- a/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
+++ b/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
@@ -197,7 +197,7 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     private URI getRequestUri(final Request request, final URI baseUri) {
         try {
             final String serverAddress = getServerAddress(baseUri);
-            String uri = request.getRequestURI();
+            String uri = request.getPathInfo();
 
             final String queryString = request.getQueryString();
             if (queryString != null) {

--- a/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ContextHandlerTest.java
+++ b/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ContextHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://oss.oracle.com/licenses/CDDL+GPL-1.1
+ * or LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package org.glassfish.jersey.jetty;
+
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class ContextHandlerTest extends AbstractJettyServerTester {
+
+    @Path("helloworld")
+    public static class HelloWorldResource {
+        public static final String CLICHED_MESSAGE = "Hello World!";
+
+        @GET
+        public String getHello() {
+            return CLICHED_MESSAGE;
+        }
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        startServer("/uri-context" , HelloWorldResource.class);
+        Client client = ClientBuilder.newClient();
+        Response response = client.target(getUri()).path("uri-context/helloworld").request().get();
+        String entity = response.readEntity(String.class);
+        assertEquals(HelloWorldResource.CLICHED_MESSAGE, entity);
+    }
+
+}


### PR DESCRIPTION
`JettyHttpContainer` has logic to support non-default context paths, but it miscalculates the request URI: the `getRequestURI` contains the context path, and it is appended `getServerAddress(baseUri)`, which also (correctly) contains the context path.  Use `getPathInfo` instead, which excludes the context path.

(I am listed for Jersey in the [Oracle Contributor Agreement](http://www.oracle.com/technetwork/community/oca-486395.html#w) under "Workiva Inc.")