### PR TITLE
Fix Netty for unsized large responses

### DIFF
--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/NettyResponseWriter.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/NettyResponseWriter.java
@@ -142,12 +142,7 @@ class NettyResponseWriter implements ContainerResponseWriter {
         if (req.method() != HttpMethod.HEAD && (contentLength > 0 || contentLength == -1)) {
 
             JerseyChunkedInput jerseyChunkedInput = new JerseyChunkedInput(ctx.channel());
-
-            if (HttpUtil.isTransferEncodingChunked(response)) {
-                ctx.write(new HttpChunkedInput(jerseyChunkedInput)).addListener(FLUSH_FUTURE);
-            } else {
-                ctx.write(new HttpChunkedInput(jerseyChunkedInput)).addListener(FLUSH_FUTURE);
-            }
+            ctx.writeAndFlush(new HttpChunkedInput(jerseyChunkedInput));
             return jerseyChunkedInput;
 
         } else {


### PR DESCRIPTION
`HttpChunkedInput` needs to be flushed so that it can read input immediately.  Otherwise, all writes are buffered until the response is fully written, which overflows the buffer if enough data is sent.

This only partially fixes the problem since clients that are reading slower than one chunk per 10sec can still overflow the buffer, but it is often sufficient in practice.  To fully fix, `JerseyChunkedInput` needs to be reworked to block indefinitely when there's no space but to allow the `ChunkedInput.close` to awaken the writer and throw an `IOException`.  (The existing close implements both the `OutputStream` and `ChunkedInput`, but it appears to be implemented as the latter only, so the `removeLast`/`add` appears to race with concurrent writes.)

Updates #3500 

(I am listed for Jersey in the [Oracle Contributor Agreement](http://www.oracle.com/technetwork/community/oca-486395.html#w) under "Workiva Inc.")